### PR TITLE
fix(tools): pr-resolve-threads $PrNumber: parse error

### DIFF
--- a/tools/pr-resolve-threads.ps1
+++ b/tools/pr-resolve-threads.ps1
@@ -46,7 +46,7 @@ if ($threads.Count -eq 0) {
     exit 0
 }
 
-Write-Host "Unresolved threads on PR #$PrNumber:" -ForegroundColor Cyan
+Write-Host "Unresolved threads on PR #${PrNumber}:" -ForegroundColor Cyan
 foreach ($thread in $threads) {
     $comment = $thread.comments.nodes | Select-Object -First 1
     $path = if ($null -ne $comment -and $comment.path) { $comment.path } else { '(unknown path)' }


### PR DESCRIPTION
## Fix

`tools/pr-resolve-threads.ps1` line 49 has `$PrNumber:` which PowerShell parses as variable reference followed by drive-letter separator, throwing:

```
Variable reference is not valid. ':' was not followed by a valid variable name character.
Consider using ${} to delimit the name.
```

Wrap as `${PrNumber}:` to delimit the variable name. One-character fix.

## How it surfaced

Hit during the PR #284 review cycle when trying to inspect unresolved threads — had to work around with raw GraphQL. Documented in [memory/repo/kerrigan-conventions.md](https://github.com/Kixantrix/kerrigan/blob/main/memory/repo/kerrigan-conventions.md) as a known PowerShell quirk.

## Test plan

- Manual: run `./tools/pr-resolve-threads.ps1 287 -DryRun` (closed PR, no threads — just exercises the path)
- Existing tests pass

## Why not dispatched to cloud agent

Single-character fix to a harness helper. Per `.github/agents/kerrigan.md` (Shaper hat): "small, contained harness edits where round-tripping through a PR would add more friction than value" — but I'm still going through PR rather than direct push, since branch protection is now the right default even for the conductor.
