### PR TITLE
fix(tools): pr-promote.ps1 ASCII markers (PS 5.1 encoding)

### DIFF
--- a/tools/pr-promote.ps1
+++ b/tools/pr-promote.ps1
@@ -60,12 +60,12 @@ function Invoke-Step {
         if ($LASTEXITCODE -ne 0) {
             throw ("Command exited with code {0}." -f $LASTEXITCODE)
         }
-        Write-Host ("✓ {0}" -f $Label)
+        Write-Host ("[OK] {0}" -f $Label)
         return $true
     } catch {
-        Write-Host ("✗ {0}: {1}" -f $Label, $_.Exception.Message)
+        Write-Host ("[FAIL] {0}: {1}" -f $Label, $_.Exception.Message)
         if ($ContinueOnFailure) {
-            Write-Host ("✓ Continuing after step failure: {0}" -f $Label) -ForegroundColor Yellow
+            Write-Host ("[WARN] Continuing after step failure: {0}" -f $Label) -ForegroundColor Yellow
             return $true
         }
         return $false
@@ -74,24 +74,24 @@ function Invoke-Step {
 
 $repo = '(unknown)/(unknown)'
 if ($DryRun) {
-    Write-Host "✓ [dry-run] gh repo view --json nameWithOwner --jq "".nameWithOwner"""
+    Write-Host "[OK] [dry-run] gh repo view --json nameWithOwner --jq "".nameWithOwner"""
 } else {
     $repoOutput = gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>&1
     if ($LASTEXITCODE -ne 0) {
-        Write-Host ("✗ Resolve repository owner/name: {0}" -f ($repoOutput -join "`n"))
+        Write-Host ("[FAIL] Resolve repository owner/name: {0}" -f ($repoOutput -join "`n"))
         exit 1
     }
     $repo = ($repoOutput -join "`n").Trim()
     if ([string]::IsNullOrWhiteSpace($repo)) {
-        Write-Host "✗ Resolve repository owner/name: empty response from gh repo view."
+        Write-Host "[FAIL] Resolve repository owner/name: empty response from gh repo view."
         exit 1
     }
-    Write-Host "✓ Resolved repository owner/name."
+    Write-Host "[OK] Resolved repository owner/name."
 }
 
 if (-not (Invoke-Step -Label "Ready PR #$PrNumber" -ContinueOnFailure -Command {
     if ($DryRun) {
-        Write-Host "✓ [dry-run] gh pr ready $PrNumber"
+        Write-Host "[OK] [dry-run] gh pr ready $PrNumber"
     } else {
         gh pr ready $PrNumber | Out-Null
     }
@@ -101,7 +101,7 @@ if (-not (Invoke-Step -Label "Ready PR #$PrNumber" -ContinueOnFailure -Command {
 
 if (-not (Invoke-Step -Label "Update branch for PR #$PrNumber" -Command {
     if ($DryRun) {
-        Write-Host "✓ [dry-run] gh pr update-branch $PrNumber"
+        Write-Host "[OK] [dry-run] gh pr update-branch $PrNumber"
     } else {
         gh pr update-branch $PrNumber | Out-Null
     }
@@ -110,11 +110,11 @@ if (-not (Invoke-Step -Label "Update branch for PR #$PrNumber" -Command {
 }
 
 if ($SkipReviewer) {
-    Write-Host "✓ Skip reviewer request (requested by -SkipReviewer)."
+    Write-Host "[SKIP] Skip reviewer request (requested by -SkipReviewer)."
 } else {
     if (-not (Invoke-Step -Label "Request Copilot reviewer for PR #$PrNumber" -Command {
         if ($DryRun) {
-            Write-Host "✓ [dry-run] gh api --method POST repos/$repo/pulls/$PrNumber/requested_reviewers -f ""reviewers[]=copilot-pull-request-reviewer[bot]"""
+            Write-Host "[OK] [dry-run] gh api --method POST repos/$repo/pulls/$PrNumber/requested_reviewers -f ""reviewers[]=copilot-pull-request-reviewer[bot]"""
         } else {
             $reviewerOutput = gh api --method POST "repos/$repo/pulls/$PrNumber/requested_reviewers" -f "reviewers[]=copilot-pull-request-reviewer[bot]" 2>&1
             if ($LASTEXITCODE -ne 0 -and ($reviewerOutput -join "`n") -notmatch '422') {
@@ -131,7 +131,7 @@ if ($SkipReviewer) {
 
 if (-not (Invoke-Step -Label "Arm auto-merge ($MergeMethod) for PR #$PrNumber" -Command {
     if ($DryRun) {
-        Write-Host "✓ [dry-run] gh pr merge $PrNumber --auto --$MergeMethod"
+        Write-Host "[OK] [dry-run] gh pr merge $PrNumber --auto --$MergeMethod"
     } else {
         gh pr merge $PrNumber --auto --$MergeMethod | Out-Null
     }


### PR DESCRIPTION
## Fix

`tools/pr-promote.ps1` (merged in #284) uses `✓` and `✗` characters in `Write-Host` strings but the file is saved as UTF-8 without BOM. PowerShell 5.1 (default Windows) reads files without BOM as Windows-1252, so each 3-byte UTF-8 sequence is mojibake'd into 3 chars like `âœ"`, which breaks string parsing:

```
Unexpected token '{' in expression or statement.
The string is missing the terminator: ".
```

The script literally cannot be invoked on a default Windows PowerShell install.

## Approach

Switch the markers to ASCII (`[OK]`, `[FAIL]`, `[WARN]`, `[SKIP]`) so the file parses identically regardless of encoding. Avoids the alternative (adding a UTF-8 BOM), which is a fragile invisible-bytes fix.

## Verification

```pwsh
./tools/pr-promote.ps1 -PrNumber 290 -DryRun
# [OK] [dry-run] gh repo view ...
# [OK] [dry-run] gh pr ready 290
# [OK] Ready PR #290
# ...
```

Existing tests in `tests/test_pr_promote.py` still pass on machines with `pwsh` installed (4/5 pass on my Windows PowerShell 5.1 box; the 5th skips for `pwsh required`).

## How it surfaced

Found while dogfooding the helper on PR #290 (the `pr-resolve-threads` fix). First real invocation of `pr-promote.ps1` after merge — instant parse failure. Good reminder that "test passes in CI" ≠ "works on Windows PS 5.1 with the file's actual encoding". I'm filing this directly rather than dispatching to cloud agent because the file is unusable and blocking the PR loop.
