### PR TITLE
plan(kerrigan-dashboard): tasks.md for M2-M8

### DIFF
--- a/.github/agents/kerrigan.md
+++ b/.github/agents/kerrigan.md
@@ -61,6 +61,8 @@ When the scope is ambiguous, ask the human one question to disambiguate. Don't g
 - **Don't dispatch without a briefing packet.** A bare issue title is not enough.
 - **Don't ignore blocks.** A block means: stop and surface. Not: retry silently.
 - **Don't parallel-dispatch conflicting tasks.** Run the conflict predictor first.
+- **Don't commit `specs/projects/<name>/` artifacts without the full required set.** A project under `specs/projects/` must have at minimum: `spec.md`, `acceptance-tests.md`, `architecture.md`, `plan.md`, `tasks.md`, `test-plan.md`. Deployable projects (spec mentions deploy/production/runtime, or has a runbook) also need `runbook.md` + `cost-plan.md`. The opt-out for docs-only / non-deployable work is dropping a `.tinyspec` marker file in the project dir (shrinks the required set to `spec/acceptance-tests/plan/tasks`). Always run `python -m tools.validators.check_artifacts` locally before committing. The required spec.md H2 sections are `Goal`, `Scope`, `Non-goals`, `Acceptance criteria`; architecture.md needs `Overview`, `Components & interfaces`, `Tradeoffs`, `Security & privacy notes` (exact heading names).
+- **Don't admin-bypass branch protection for `specs/projects/*` work.** CI gates (`check_artifacts.py` in particular) exist to catch missing required files. Bypassing means landing broken state on `main`, which then fails the check on every subsequent PR branch until repaired. If a spec artifact PR is mid-iteration and CI is failing for a reason you understand, fix the cause rather than bypassing. Branch protection is right by default — even the conductor goes through PR for these paths.
 
 ---
 

--- a/specs/projects/kerrigan-dashboard/acceptance-tests.md
+++ b/specs/projects/kerrigan-dashboard/acceptance-tests.md
@@ -1,0 +1,103 @@
+# Acceptance tests: kerrigan-dashboard
+
+Each test below maps to one AC from [`spec.md`](./spec.md) and the corresponding task in [`tasks.md`](./tasks.md). Tests are sized at the unit / integration / E2E level appropriate to the AC and are owned by the milestone that introduces the feature.
+
+Test locations (created by the corresponding tasks):
+
+- `apps/kerrigan-dashboard/src/**/*.test.ts(x)` — Vitest unit + component
+- `apps/kerrigan-dashboard/tests/e2e/**.spec.ts` — Playwright E2E
+- `tools/kerrigan-mcp/test/**.test.ts` — MCP integration
+- `tests/projects/kerrigan_dashboard/**.py` — pre-vis + cross-cutting checks
+- `scripts/smoke.ps1` / `.sh` — build + launch smoke
+
+## AC-001: Cold start <1s to portfolio view
+
+- [ ] **Given** the app is launched from cold **When** the window appears **Then** the portfolio view is rendered within 1s measured from process start (Task M2.4 — Playwright `e2e/portfolio.spec.ts` `cold-start-under-1s`)
+
+## AC-002: Portfolio lists every project from `~/.kerrigan/projects.json`
+
+- [ ] **Given** a `~/.kerrigan/projects.json` fixture with three projects **When** the portfolio renders **Then** three cards appear each showing name, repo count, current wave, block count, intervention count, last-PR-merged timestamp (Task M2.4 — `portfolio.spec.ts` `renders-all-projects`)
+
+## AC-003: Portfolio → project detail navigation <500ms
+
+- [ ] **Given** a rendered portfolio card **When** the card is clicked **Then** the project detail view replaces the portfolio within 500ms (Task M3.3 — `project-detail.spec.ts` `nav-under-500ms`)
+
+## AC-004: DAG renders one node per plan stage
+
+- [ ] **Given** a fixture plan with N H2 stage headings **When** the project detail opens **Then** the React Flow canvas renders exactly N nodes (Task M3.3 — `dag.spec.ts` `one-node-per-stage`, parser covered by `plan-parser.test.ts`)
+
+## AC-005: DAG node status color taxonomy
+
+- [ ] **Given** stages mapped to each status (planned, dispatched, in-review, blocked, needs-attestation, needs-human-test, merged) **When** the DAG renders **Then** each node shows the matching color from the locked taxonomy (Task M3.2 + M3.3 — `status.test.ts` table + `dag.spec.ts` `colors-by-status`)
+
+## AC-006: PR opened → particle within 5s of poll detection
+
+- [ ] **Given** a tracked repo with a fixture "open PR" event **When** the poll cycle completes **Then** a particle animates from a PR card into the matching stage node within 5s (Task M7.2 — `pr-flow.spec.ts` `open-pr-emits-particle`, fake clock for poll interval)
+
+## AC-007: PR merged → absorb + green pulse
+
+- [ ] **Given** a particle in flight for a PR **When** the PR transitions to merged **Then** the particle absorbs into the node and the node pulses green (Task M7.2 — `pr-flow.spec.ts` `merge-absorb-and-pulse`)
+
+## AC-008: Plan editor round-trip with no fidelity loss
+
+- [ ] **Given** a corpus of sample plan markdown files **When** loaded into Tiptap and saved unchanged **Then** the saved output is byte-equivalent to the input (Task M6.1 — property test `plan-editor.test.ts` `round-trip-byte-equivalent`)
+
+## AC-009: Save commits to per-session branch + DAG re-renders <2s
+
+- [ ] **Given** an active editing session **When** Ctrl-S or blur fires **Then** a commit is pushed to `plan-edits/<timestamp>-<sha>` and the DAG re-renders within 2s of save completion (Task M6.2 — `plan-save.spec.ts` `commits-and-rerenders`)
+
+## AC-010: Chat pane spawns `copilot --acp` and streams to rich components
+
+- [ ] **Given** a project is opened **When** the chat pane mounts **Then** a `copilot --acp` subprocess is spawned and `message_chunk`, `tool_call`, `tool_result`, `thought` events render as distinct React components (Task M4.1 + M4.2 — `acp-client.test.ts` with mock ACP, `chat.spec.ts` `rich-renderers`)
+
+## AC-011: MCP tools invocation refreshes the relevant pane
+
+- [ ] **Given** the chat agent invokes `kerrigan.dispatch`, `kerrigan.plan-update`, `kerrigan.block-resolve`, or `kerrigan.conflict-predict` **When** the tool returns **Then** the affected pane (DAG / plan editor / inbox) refreshes without manual reload (Task M5.4 — `mcp-sidecar.spec.ts` `tool-result-refreshes-pane` for each tool)
+
+## AC-012: Inbox aggregates across all projects
+
+- [ ] **Given** fixtures across three projects with open blocks, attestation requests, `agent:wait + capture` issues, and PRs with unresolved review threads **When** the inbox loads **Then** all items appear in the unified feed (Task M8.1 — `inbox.test.ts` `aggregates-across-projects`)
+
+## AC-013: Inbox items link to source + disappear when resolved
+
+- [ ] **Given** an inbox item of each type **When** clicking the item **Then** navigation lands on the source DAG node / PR / issue; **When** the source is resolved **Then** the item disappears on next sync (Task M8.2 — `inbox.spec.ts` `links-and-removes-on-resolve`)
+
+## AC-014: Offline indicator + no crash
+
+- [ ] **Given** the GitHub API is unreachable **When** the portfolio loads **Then** cached state is displayed with a visible "offline — last synced HH:MM" indicator and no app crash (Task M2.4 — `portfolio.spec.ts` `offline-indicator`, with intercepted network)
+
+## AC-015: Offline edit queue + conflict surface
+
+- [ ] **Given** the app is offline **When** the user edits and saves a plan **Then** the edit serializes to `~/.kerrigan/queue/`; **When** connectivity returns **Then** the edit replays; **When** the remote plan diverged **Then** an inbox item surfaces (Task M6.3 — `plan-queue.test.ts` + `plan-conflict.spec.ts`)
+
+## AC-016: Multi-repo PR aggregation on DAG
+
+- [ ] **Given** a project entry with three repos and PRs in each **When** the DAG renders **Then** the union of all PRs informs node status (Task M3.2 — `status.test.ts` `multi-repo-aggregation`)
+
+## AC-017: No persistent credential storage
+
+- [ ] **Given** the app runs through a full session including GitHub API calls **When** the app data directory is scanned post-shutdown **Then** no GitHub token, OAuth secret, or session cookie is present (Task M2.3 — `github.test.ts` `no-token-on-disk`; also covered by `tests/projects/kerrigan_dashboard/test_no_credential_persistence.py`)
+
+## AC-018: Pre-vis HTML exists and matches design references
+
+- [ ] **Given** the merged M1 deliverable **When** opening `specs/projects/kerrigan-dashboard/previs/index.html` in a modern browser **Then** the portfolio + project detail + show-stopper variants render and visually match `design-references.md` (Task M1.1 — `tests/projects/kerrigan_dashboard/test_previs_static.py`)
+
+## AC-019: Color / type / motion budgets
+
+- [ ] **Given** the pre-vis HTML and the production app CSS **When** the budget checker scans declared tokens **Then** ≤2 neutrals + 1 brand + 1 accent, 4–5 type sizes, all transitions ≤300ms (show-stopper allowed ≤2s exception) (Task M1.1 + M2.1 — `tests/projects/kerrigan_dashboard/test_previs_budgets.py` and a CSS-token lint rule in `apps/kerrigan-dashboard/`)
+
+## AC-020: Exactly one show-stopper element
+
+- [ ] **Given** the rendered dashboard in any view **When** screening for high-weight visual elements (motion + saturation + size) **Then** exactly one element qualifies — the PR-flow animation (Task M1.1 + M7.1 — manual checkpoint at M1 sign-off + `pr-flow.spec.ts` `single-show-stopper`)
+
+## Cross-cutting tests
+
+- [ ] **Smoke**: `scripts/smoke.ps1` / `.sh` builds `tauri build`, launches the binary, asserts window opens, asserts one GitHub API call succeeds. Required for PR merge per [AGENTS.md](../../../AGENTS.md).
+- [ ] **Build matrix**: `dashboard-build.yml` runs on Windows / macOS / Linux runners; lint + Vitest + smoke pass on each.
+- [ ] **Coverage**: ≥80% line coverage on `apps/kerrigan-dashboard/src/lib/**` and `tools/kerrigan-mcp/src/**` (the logic-heavy modules) per repo testing standard.
+
+## Notes
+
+- ACs that span multiple milestones (e.g., AC-010 covers M4 vanilla + M5 MCP wiring) get one test per milestone slice rather than one monolithic test.
+- Visual / motion ACs (AC-019, AC-020) blend automated linting with a manual sign-off checkpoint at M1 — the M7 production implementation re-asserts via Playwright visual diff against the M1 chosen variant.
+- The pre-vis tests under `tests/projects/kerrigan_dashboard/` are filed in the existing Python test tree so they run inside the current `verify` workflow without waiting for the Tauri app to land.

--- a/specs/projects/kerrigan-dashboard/acceptance-tests.md
+++ b/specs/projects/kerrigan-dashboard/acceptance-tests.md
@@ -76,7 +76,7 @@ Test locations (created by the corresponding tasks):
 
 ## AC-017: No persistent credential storage
 
-- [ ] **Given** the app runs through a full session including GitHub API calls **When** the app data directory is scanned post-shutdown **Then** no GitHub token, OAuth secret, or session cookie is present (Task M2.3 — `github.test.ts` `no-token-on-disk`; also covered by `tests/projects/kerrigan_dashboard/test_no_credential_persistence.py`)
+- [ ] **Given** the app runs through a full session including GitHub API calls **When** the app data directory is scanned post-shutdown **Then** no GitHub token, OAuth secret, or session cookie is present (Task M2.3 — `github.test.ts` `no-token-on-disk` asserts no token is written during API calls; a Playwright post-shutdown scan of `~/.kerrigan/` is added in M2.4 as part of the offline-indicator E2E and fails the build if any string matches `ghp_`, `github_pat_`, or `gho_`)
 
 ## AC-018: Pre-vis HTML exists and matches design references
 
@@ -92,8 +92,9 @@ Test locations (created by the corresponding tasks):
 
 ## Cross-cutting tests
 
-- [ ] **Smoke**: `scripts/smoke.ps1` / `.sh` builds `tauri build`, launches the binary, asserts window opens, asserts one GitHub API call succeeds. Required for PR merge per [AGENTS.md](../../../AGENTS.md).
-- [ ] **Build matrix**: `dashboard-build.yml` runs on Windows / macOS / Linux runners; lint + Vitest + smoke pass on each.
+- [ ] **Smoke (current state)**: `scripts/smoke.ps1` / `.sh` perform read-only repo health checks (validators, no build/launch). They gate PR merge today.
+- [ ] **Smoke (after M2.5)**: M2.5 extends `scripts/smoke.*` so that when `apps/kerrigan-dashboard/` is present they additionally run `pnpm -C apps/kerrigan-dashboard tauri build`, assert the artifact exists, and (on the OSes where it's feasible in CI) launch the binary and assert one GitHub API call succeeds. The extended smoke continues to gate PR merge per [AGENTS.md](../../../AGENTS.md).
+- [ ] **Build matrix**: `dashboard-build.yml` runs on Windows / macOS / Linux runners; lint + Vitest + extended smoke pass on each.
 - [ ] **Coverage**: ≥80% line coverage on `apps/kerrigan-dashboard/src/lib/**` and `tools/kerrigan-mcp/src/**` (the logic-heavy modules) per repo testing standard.
 
 ## Notes

--- a/specs/projects/kerrigan-dashboard/architecture.md
+++ b/specs/projects/kerrigan-dashboard/architecture.md
@@ -8,7 +8,7 @@ The app interacts with three external systems:
 
 1. **GitHub** — read via Octokit with ETag-aware conditional polling, write via `gh` CLI shell-out where useful. Authentication is borrowed on-demand from `gh auth token`; no token is ever persisted by the dashboard itself.
 2. **GitHub Copilot CLI** — `copilot --acp` subprocess provides the chat experience. The CLI handles its own auth, model, and policy concerns; the dashboard just streams events.
-3. **Local Kerrigan MCP server** — a Node 22 / TypeScript sidecar process started by the dashboard at launch. It exposes four tools to the chat agent (`kerrigan.dispatch`, `kerrigan.plan-update`, `kerrigan.block-resolve`, `kerrigan.conflict-predict`) and emits tool-result events back to the dashboard over a control channel so panes can refresh reactively.
+3. **Local Kerrigan MCP server** — a Node 22 / TypeScript sidecar process started by the dashboard at launch. It exposes the four v1 tools enumerated in spec AC-011 (`kerrigan.dispatch`, `kerrigan.plan-update`, `kerrigan.block-resolve`, `kerrigan.conflict-predict`) and emits tool-result events back to the dashboard over a control channel so panes can refresh reactively. Any tool beyond this set is explicitly v2+ scope and must be added via a spec amendment to AC-011 before it can land.
 
 Constraints from [`spec.md`](./spec.md): cold-start <1s, no credential persistence (AC-017), offline-tolerant (AC-014, AC-015), exactly one show-stopper visual (AC-020).
 
@@ -104,7 +104,7 @@ Polling cadence: 60s default, adaptive on rate-limit pressure (AC-014 backoff). 
 - **Tauri allowlist**: locked to the minimum required scopes:
   - `fs`: read-write on `~/.kerrigan/`, read on any project's git working copy paths declared in `projects.json`.
   - `shell.execute`: only for vetted commands (`gh auth token`, `git`, `copilot --acp`); no arbitrary shell.
-  - No network capability granted to the renderer; all outbound HTTP goes through the Rust core via Octokit.
+  - **Renderer egress is restricted, not eliminated.** Octokit is a JavaScript client and runs in the renderer; the dashboard does not proxy HTTP through the Rust core. The renderer's network surface is constrained by a strict CSP (`connect-src 'self' https://api.github.com https://*.githubusercontent.com`) and the Tauri config's `http.scope` allowlist set to the same two origins. Any other outbound HTTP from the renderer (telemetry endpoints, third-party CDNs, etc.) is blocked by the browser engine and verified by a CI test that fetches a non-allowlisted origin and asserts the request fails.
 - **MCP server boundary**: binds to stdio only — no TCP/UDP listener, no Unix socket exposed beyond the parent process.
 - **Plan edit safety**: writes always go to a branch (never directly to `main`). The conflict detector blocks save when an `agent:go` issue's PR touches the same plan file.
 - **External calls**: limited to `api.github.com` and `*.githubusercontent.com`. No telemetry endpoints, no third-party analytics.

--- a/specs/projects/kerrigan-dashboard/architecture.md
+++ b/specs/projects/kerrigan-dashboard/architecture.md
@@ -1,0 +1,117 @@
+# Architecture: kerrigan-dashboard
+
+## Overview
+
+Local-first desktop application (Tauri 2 shell wrapping a React 19 + Vite frontend) that visualizes work across all of the user's Kerrigan-coordinated projects. It is a single-user, single-machine tool — there is no backend service. All persistent state lives in two places: the user's GitHub repositories (the source of truth) and `~/.kerrigan/` on the local filesystem (configuration + caches).
+
+The app interacts with three external systems:
+
+1. **GitHub** — read via Octokit with ETag-aware conditional polling, write via `gh` CLI shell-out where useful. Authentication is borrowed on-demand from `gh auth token`; no token is ever persisted by the dashboard itself.
+2. **GitHub Copilot CLI** — `copilot --acp` subprocess provides the chat experience. The CLI handles its own auth, model, and policy concerns; the dashboard just streams events.
+3. **Local Kerrigan MCP server** — a Node 22 / TypeScript sidecar process started by the dashboard at launch. It exposes four tools to the chat agent (`kerrigan.dispatch`, `kerrigan.plan-update`, `kerrigan.block-resolve`, `kerrigan.conflict-predict`) and emits tool-result events back to the dashboard over a control channel so panes can refresh reactively.
+
+Constraints from [`spec.md`](./spec.md): cold-start <1s, no credential persistence (AC-017), offline-tolerant (AC-014, AC-015), exactly one show-stopper visual (AC-020).
+
+## Components & interfaces
+
+```
++----------------------------------------------------------------+
+| Tauri shell (Rust)                                             |
+|  - window/lifecycle, tauri allowlist (fs + shell, locked down) |
+|  - spawns: kerrigan-mcp sidecar, copilot --acp on demand       |
++----------------------------------------------------------------+
+| Frontend (React 19 + Vite + Tailwind 4)                        |
+|                                                                |
+|  routes/portfolio  routes/project        routes/inbox          |
+|       |                  |                    |                |
+|  components/             components/    components/            |
+|   ProjectCard             Dag             InboxItem            |
+|                           PlanEditor      CaptureTriage        |
+|                           Chat                                 |
+|                           PrFlowOverlay (show-stopper)         |
+|                                                                |
+|  lib/                                                          |
+|   projects.ts     - read+validate ~/.kerrigan/projects.json    |
+|   github.ts       - Octokit + ETag cache + gh-auth shell-out   |
+|   plan-parser.ts  - markdown -> {nodes, edges}                 |
+|   status.ts       - PR/issue/block -> node status              |
+|   acp-client.ts   - spawn+manage copilot --acp                 |
+|   mcp-sidecar.ts  - spawn+wire kerrigan-mcp                    |
+|   plan-save.ts    - per-session branch, push, draft PR         |
+|   plan-queue.ts   - offline edit queue + replay                |
+|   inbox.ts        - cross-project aggregator                   |
++----------------------------------------------------------------+
+| Sidecar: tools/kerrigan-mcp/ (Node 22 / TypeScript)            |
+|  MCP server over stdio                                         |
+|  tools: dispatch, plan-update, block-resolve, conflict-predict |
++----------------------------------------------------------------+
+```
+
+Inter-process channels:
+
+- `Tauri shell ↔ Frontend`: Tauri command + event bridge (no extra surface).
+- `Frontend ↔ copilot --acp`: ACP JSON-RPC over the subprocess stdio. Wrapped by `lib/acp-client.ts`.
+- `Frontend ↔ kerrigan-mcp`: MCP stdio. The MCP config is passed to `copilot --acp` via `--additional-mcp-config` so the chat agent can call our tools. The dashboard also subscribes to a side-channel control stream from the sidecar for cache-invalidation events.
+- `Sidecar ↔ GitHub`: same Octokit/gh-auth path as the frontend; sidecar performs writes (issues, PRs) on the user's behalf.
+
+## Data flow (conceptual)
+
+```
+projects.json --> lib/projects.ts -----+
+                                       |
+                                       v
+                            +----------+----------+
+GitHub (PRs/issues/blocks)->| lib/github.ts (poll)|--> status derivation
+                            +----------+----------+        |
+                                       |                   v
+plan.md (per project) ----> lib/plan-parser.ts ----> DAG render
+                                                          ^
+                                                          |
+chat input --> acp-client --> Copilot CLI --> tool_call --+
+                                                |
+                                                v
+                                        kerrigan-mcp tools
+                                          |        |
+                                          v        v
+                                   GitHub writes   plan.md edit + PR
+                                          |        |
+                                          v        v
+                                  control event back to frontend
+                                          |
+                                          v
+                              pane refresh (DAG / editor / inbox)
+```
+
+Polling cadence: 60s default, adaptive on rate-limit pressure (AC-014 backoff). ETag cache short-circuits 304s. Writes are immediate and trigger a fast-path refresh of just the affected pane.
+
+## Tradeoffs
+
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| Shell | Tauri 2 | Electron | Smaller bundle, Rust core, native webview; fits a single-user local tool. |
+| Frontend | React 19 + Vite | SolidJS, Svelte | Largest ecosystem for the niche libs we need (React Flow, Tiptap). |
+| DAG | React Flow 12 + dagre | Cytoscape, custom canvas | Battle-tested node/edge UI; auto-layout in the box; fits "≤200 nodes interactive in <1s" budget. |
+| Plan editor | Tiptap | Lexical, CodeMirror | Best markdown round-trip story; AI Toolkit path available. Lexical kept as swap-in behind a thin interface. |
+| Chat | `copilot --acp` subprocess | Embed web view of github.com/copilot, write our own client against the OpenAI API | ACP is purpose-built for embedding; authentic Copilot; no API key juggling; auth follows the user's `gh` session. |
+| MCP transport | Local stdio sidecar | Local HTTP server | No port exposure; tighter security; aligns with Copilot CLI's MCP config model. |
+| Auth | `gh auth token` shell-out per call | OAuth flow with token at rest | Zero persistence (AC-017); reuses the user's existing `gh` setup. |
+| Save model | Branch-per-edit-session + draft PR | Direct commit to main | Plays nicely with branch protection and parallel agent edits; conflicts surfaced cleanly. |
+| Offline writes | Local queue in `~/.kerrigan/queue/` | Block writes when offline | Conductor can capture intent and replay; preserves the always-responsive feel. |
+
+## Security & privacy notes
+
+- **Credentials**: zero persistence. The app never writes a GitHub token, OAuth secret, or session cookie to disk. Every API call resolves auth fresh via `gh auth token`. Verified by AC-017 test + a post-shutdown scan of the data directory.
+- **Tauri allowlist**: locked to the minimum required scopes:
+  - `fs`: read-write on `~/.kerrigan/`, read on any project's git working copy paths declared in `projects.json`.
+  - `shell.execute`: only for vetted commands (`gh auth token`, `git`, `copilot --acp`); no arbitrary shell.
+  - No network capability granted to the renderer; all outbound HTTP goes through the Rust core via Octokit.
+- **MCP server boundary**: binds to stdio only — no TCP/UDP listener, no Unix socket exposed beyond the parent process.
+- **Plan edit safety**: writes always go to a branch (never directly to `main`). The conflict detector blocks save when an `agent:go` issue's PR touches the same plan file.
+- **External calls**: limited to `api.github.com` and `*.githubusercontent.com`. No telemetry endpoints, no third-party analytics.
+- **Subprocess sandboxing**: Copilot CLI runs as a child process inheriting only the user's environment minus `KERRIGAN_*` variables that may contain configured paths.
+- **Static scan in CI**: `dashboard-build.yml` runs `gitleaks` and a custom check that fails the build if any `gh auth token` output is logged, written to a file, or passed to a non-allowlisted process.
+
+## Open questions
+
+- Whether to ship the kerrigan-mcp server as a separate binary or bundle it inside the Tauri sidecar process. Decision deferred to M5 spike.
+- Whether plan-edit branches should target `main` directly or a per-project `plan-edits` integration branch. Decision deferred to M6 spike.

--- a/specs/projects/kerrigan-dashboard/cost-plan.md
+++ b/specs/projects/kerrigan-dashboard/cost-plan.md
@@ -1,0 +1,51 @@
+# Cost plan: kerrigan-dashboard
+
+> This is a local desktop app. There is no cloud infrastructure to pay for. Costs are CI minutes, code-signing certificates, and the user-side burden of Copilot CLI usage which is the user's own subscription.
+
+## Cost drivers
+
+| Driver | Bearer | Variable? | Notes |
+|---|---|---|---|
+| GitHub Actions minutes for `dashboard-build` matrix (Win/macOS/Linux) | Repo owner | Per PR + per release tag | macOS minutes are 10× Linux minutes — biggest single line. |
+| GitHub API calls during dev/test/CI | Repo owner | Bounded by rate limit | Free until rate limit; integration tests use ETags to stay well under. |
+| Code-signing certificates | Repo owner | Annual flat fee | Windows EV cert ~$300/yr; Apple Developer Program $99/yr. Deferred until first public release. |
+| Copilot CLI usage in production (end-user) | End-user | Per-token | User's own Copilot subscription; the dashboard does not proxy or pool. |
+| Storage for build artifacts on GitHub releases | Repo owner | Per release MB | Tauri installers are ~10-30 MB each × 3 OSes × N releases. Negligible until release count is high. |
+| Developer machine resources during build | Developer | Local | First `tauri build` takes 5-10 min on a modern laptop; cache reduces subsequent builds. |
+
+## Baseline estimate
+
+**Pre-public-release** (development through M8):
+
+- **CI minutes**: assume 20 PRs × matrix (3 OSes × ~10 min average) = ~600 min/month. Within the free tier for a personal repo (2000 Linux min, 200 macOS min — the macOS quota is the real constraint). Mitigation: gate the macOS leg of `dashboard-build` to PRs that change `apps/kerrigan-dashboard/**`.
+- **Certificates**: $0. Unsigned dev builds.
+- **GitHub API**: $0. Within rate limits.
+- **Total**: ~$0 / month of out-of-pocket cost.
+
+**Post-public-release** (steady state, low usage):
+
+- **CI minutes**: ~1000-1500 min/month including release builds. Likely overruns the macOS free tier; budget ~$10-20/month if it does.
+- **Certificates**: ~$400 / year amortized → ~$35 / month.
+- **GitHub API**: $0.
+- **Total**: ~$50 / month if we maintain code signing.
+
+## Guardrails (budgets/alerts/tags)
+
+- **CI minute alert**: GitHub will surface usage at 75% / 90% of the monthly free quota. No additional alerting needed at this scale.
+- **Path-filter the macOS leg** of `dashboard-build` to only run when `apps/kerrigan-dashboard/**`, `src-tauri/**`, or the workflow itself changes. Skip on docs-only PRs.
+- **Cache aggressively**: `actions/cache` for the Rust target dir and the pnpm store. Aim for ≥80% cache hit on incremental PRs.
+- **Release cadence**: target ≤1 release per week post-launch to keep release CI cost predictable.
+- **Tag**: there are no cloud resources to tag. Repo owner is the only cost center.
+
+## Scale assumptions
+
+- Single repo owner; no team/seat licensing.
+- ≤10 PRs per day across the whole kerrigan monorepo (with most touching paths outside the dashboard scope).
+- ≤1 release per week post-launch.
+- ≤100 daily active end-users in year one (irrelevant to dashboard cost — end-users pay their own Copilot CLI usage; we incur only the GitHub release storage which is free).
+- If end-user count grows materially (>1000), revisit auto-updater bandwidth and consider a CDN-backed Tauri updater endpoint; that would be the first real cloud-cost line.
+
+## Decisions deferred
+
+- Whether to maintain code signing or ship as "unsigned, accept the OS warning" indefinitely. Signing improves UX but costs $400/year + maintenance.
+- Whether to publish to platform stores (Microsoft Store, Mac App Store) — each adds $99-100/year and notable submission overhead. Not in v1.

--- a/specs/projects/kerrigan-dashboard/plan.md
+++ b/specs/projects/kerrigan-dashboard/plan.md
@@ -157,7 +157,7 @@ The Tauri app lives under `apps/` so it can coexist with future apps without ren
 - Inbox aggregator pulling from all projects: open blocks, `agent:wait + capture` issues, PRs with unresolved review threads, attestation requests parsed from task ACs.
 - Inbox view (filterable by project, type, age).
 - Per-item actions: "dispatch" (sends to chat with prefilled prompt), "close with reason", "snooze".
-- Mobile-capture triage: side panel renders the captured idea + suggests a briefing draft via chat MCP `briefing-gen` tool.
+- Mobile-capture triage: side panel renders the captured idea and offers a "draft briefing" action that calls the in-scope `kerrigan.plan-update` MCP tool (M5.2) to insert a briefing-shaped block into a draft PR on the target project. A dedicated `kerrigan.briefing-gen` tool is out of v1 scope per spec AC-011 and is deferred to a future spec amendment.
 
 **Acceptance**: AC-012, AC-013.
 

--- a/specs/projects/kerrigan-dashboard/runbook.md
+++ b/specs/projects/kerrigan-dashboard/runbook.md
@@ -1,0 +1,83 @@
+# Runbook: kerrigan-dashboard
+
+> "Deployment" for this project means publishing signed installers for Windows / macOS / Linux from a GitHub release. There is no server to operate. "Operate" means the developer running the app on their own machine.
+
+## Deploy
+
+**Release flow** (driven by `dashboard-build.yml`, gated by Task M2.5):
+
+1. Conductor pushes a tag matching `dashboard-v*.*.*` on `main`.
+2. The CI matrix builds the Tauri app on `windows-latest`, `macos-14`, `ubuntu-22.04`.
+3. Each runner produces signed installers (MSI on Windows, DMG on macOS, AppImage + .deb on Linux) and uploads as workflow artifacts.
+4. A release job pulls the artifacts and creates a GitHub release with checksums + Tauri updater manifest.
+5. The auto-updater in already-installed apps detects the new release on next launch via the Tauri updater channel.
+
+**Code signing**:
+
+- Windows: signtool with the certificate stored in `KERRIGAN_WINDOWS_SIGNING_PFX` / `KERRIGAN_WINDOWS_SIGNING_PASSWORD` repo secrets.
+- macOS: notarized via `notarytool` with `KERRIGAN_APPLE_ID`, `KERRIGAN_APPLE_PASSWORD`, and the Developer ID certificate in `KERRIGAN_MACOS_SIGNING_P12`.
+- Linux: no signing required; AppImage + Debian package only.
+
+Signing infrastructure is deferred until the first public release (post-M8). For internal dev builds, unsigned binaries are acceptable and the runbook surfaces a clear "unsigned development build" indicator in the app footer.
+
+## Operate
+
+**Daily use**:
+
+- Launch the dashboard from the OS app menu (or via `kerrigan-dashboard` on PATH on Linux).
+- Configuration lives in `~/.kerrigan/projects.json`. Edit by hand or via the in-app project picker.
+- The app reads `gh auth token` on every API call; if `gh` is not authenticated, the offline indicator stays lit and a banner prompts `gh auth login`.
+
+**Health indicators**:
+
+- Footer shows: Copilot CLI version, GitHub poll state (live / offline / rate-limited), MCP sidecar status (running / restarting / disabled).
+- If the MCP sidecar dies, the app auto-restarts it once. Repeated failures within 60s disable it and surface a banner; chat continues to work without Kerrigan tools.
+
+## Debug
+
+| Symptom | Where to look | Common cause |
+|---|---|---|
+| App won't launch | `~/.kerrigan/logs/launcher.log` | Missing Tauri runtime dependency; check OS install docs. |
+| Chat pane shows "Copilot CLI not found" | shell PATH | `@github/copilot` not installed; run `npm i -g @github/copilot`. |
+| Chat pane shows "ACP version too old" | `copilot --version` | Below the pinned minimum; upgrade Copilot CLI. |
+| DAG shows all "unknown" status | `~/.kerrigan/logs/poll.log` | GitHub auth failed or rate-limited; check `gh auth status`. |
+| Plan save errors with "conflict" | `~/.kerrigan/queue/<project>/` | An active cloud-agent PR is touching the same plan file; resolve via inbox or wait. |
+| Sidecar repeatedly crashes | `~/.kerrigan/logs/mcp.log` | Likely Octokit error from a missing/invalid PAT — re-run `gh auth login`. |
+
+**Verbose logging**: set `KERRIGAN_LOG=debug` before launching the app.
+
+## Rollback
+
+**App side** (per-user):
+
+- Tauri auto-updater keeps the previous installed version's binary one step back. To roll back, use the in-app "About → Roll back to previous version" action, which restores the prior binary and pins the updater for 24h.
+- Manual rollback: uninstall and reinstall the previous release from the GitHub releases page.
+
+**Release side** (publisher):
+
+- Tag a hotfix (`dashboard-vX.Y.Z+1`) that reverts the offending commit; the auto-updater serves it on next launch.
+- If a release is actively harmful, mark the release as "pre-release" on GitHub — the updater skips pre-release channels by default.
+
+**Data side**:
+
+- The dashboard never destructively modifies user data; "rollback" of state is just deleting `~/.kerrigan/` (caches, queued edits will be lost; `projects.json` should be backed up).
+- Plan edits made by the dashboard live on per-session branches in GitHub; revert by closing the draft PR and deleting the branch.
+
+## Secrets & access
+
+**Secrets the app needs at runtime**:
+
+- GitHub PAT: borrowed on demand via `gh auth token`. Never stored by the app.
+- Copilot CLI session: managed by `copilot` itself in its own config; the dashboard does not read or write it.
+
+**Secrets the build/release pipeline needs**:
+
+| Secret | Purpose | Rotation |
+|---|---|---|
+| `KERRIGAN_WINDOWS_SIGNING_PFX` | Authenticode signing | At certificate expiry (annual). |
+| `KERRIGAN_WINDOWS_SIGNING_PASSWORD` | PFX passphrase | With certificate. |
+| `KERRIGAN_MACOS_SIGNING_P12` | Apple Developer ID | At certificate expiry. |
+| `KERRIGAN_APPLE_ID` / `KERRIGAN_APPLE_PASSWORD` | Notarization | At Apple ID password change. |
+| `KERRIGAN_TAURI_UPDATER_PRIVATE_KEY` | Sign Tauri updater manifest | Only on key compromise — rotating invalidates auto-update for installed users. |
+
+**Access**: secrets are scoped to the `dashboard-build` environment. Only the release workflow can read them. PRs from forks never receive these secrets (workflow guarded by `pull_request_target` with manual approval).

--- a/specs/projects/kerrigan-dashboard/runbook.md
+++ b/specs/projects/kerrigan-dashboard/runbook.md
@@ -8,8 +8,8 @@
 
 1. Conductor pushes a tag matching `dashboard-v*.*.*` on `main`.
 2. The CI matrix builds the Tauri app on `windows-latest`, `macos-14`, `ubuntu-22.04`.
-3. Each runner produces signed installers (MSI on Windows, DMG on macOS, AppImage + .deb on Linux) and uploads as workflow artifacts.
-4. A release job pulls the artifacts and creates a GitHub release with checksums + Tauri updater manifest.
+3. Each runner produces an installer (MSI on Windows, DMG on macOS, AppImage + .deb on Linux). **Signing is conditional**: if the relevant signing secrets are present in the workflow environment, the installer is signed (Authenticode on Windows, notarized on macOS); otherwise the workflow produces an unsigned **internal/dev build** and labels the GitHub release accordingly. The first public release upgrades this path to signed by populating the secrets — see *Code signing* below.
+4. A release job pulls the artifacts and creates a GitHub release with checksums + Tauri updater manifest. Internal/dev releases are marked as GitHub `pre-release` so the auto-updater's stable channel skips them.
 5. The auto-updater in already-installed apps detects the new release on next launch via the Tauri updater channel.
 
 **Code signing**:

--- a/specs/projects/kerrigan-dashboard/tasks.md
+++ b/specs/projects/kerrigan-dashboard/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: kerrigan-dashboard
+
+Tasks decompose [`plan.md`](./plan.md) into single-dispatch units. Each task is one cloud-agent issue with its own briefing packet (in `.specify/briefings/<task-id>.md`).
+
+Format: one task → one PR. "Done when" must be objectively checkable. "Links" cite the AC, plan section, or architecture decision. "Dependencies" use the schema from [`_template/tasks.md`](../_template/tasks.md).
+
+Wave structure (from [`plan.md`](./plan.md#sequencing-notes)):
+
+- **wave-1**: M1 (pre-vis) — single task, in flight as issue #288.
+- **wave-2**: M2 tasks (Tauri skeleton + portfolio).
+- **wave-3**: M3 + M4 tasks parallel.
+- **wave-4**: M5 + M6 tasks parallel.
+- **wave-5**: M7 + M8 tasks parallel.
+
+Within a milestone, tasks are sequenced by their declared dependencies. The conductor regenerates `.specify/waves.yaml` before each dispatch via `kerrigan-conflict-predictor`.
+
+---
+
+## Milestone 1: Pre-vis (in flight)
+
+- [ ] Task M1.1: Pre-vis HTML + animation prototype
+  - Done when: `specs/projects/kerrigan-dashboard/previs/index.html` renders the portfolio view, project detail 3-pane, and three show-stopper variants; `design-references.md` "Open visual decisions" section becomes "Decisions locked"
+  - Links: spec.md AC-018, AC-019, AC-020; plan.md M1
+  - Tracked as: #288
+
+---
+
+## Milestone 2: Tauri skeleton + portfolio (wave-2)
+
+- [ ] Task M2.1: Tauri 2 + Vite + React + TS + Tailwind project scaffold
+  - Done when: `apps/kerrigan-dashboard/` builds via `pnpm tauri build` on Windows/macOS/Linux; `pnpm dev` opens a Tauri window with a placeholder route; Tailwind 4 configured with the design tokens from M1; ESLint + Prettier + tsconfig strict pass
+  - Links: plan.md § Project layout, § Tech stack; spec.md AC-001 (cold start)
+  - Dependencies: ~#288 (M1 design tokens consumed)
+  - Touch: `apps/kerrigan-dashboard/**`
+  - Read-only: everything else
+  - Tests: smoke (`scripts/smoke.ps1`/`.sh` invokes `tauri build` and asserts artifact)
+
+- [ ] Task M2.2: `lib/projects.ts` — `~/.kerrigan/projects.json` reader + schema validator
+  - Done when: TS module reads, validates (zod), and watches the file; emits typed `ProjectConfig[]`; handles missing/malformed file gracefully (returns empty + surfaces error)
+  - Links: spec.md § Multi-repo / multi-project; AC-014 (offline)
+  - Dependencies: #(M2.1)
+  - Touch: `apps/kerrigan-dashboard/src/lib/projects.ts`, `apps/kerrigan-dashboard/src/lib/projects.test.ts`
+  - Tests: Vitest unit (8+ cases incl. malformed JSON, missing file, schema violations, hot-reload)
+
+- [ ] Task M2.3: `lib/github.ts` — Octokit wrapper with `gh auth token` shell-out + ETag polling
+  - Done when: module exposes `getRepo`, `listOpenPRs`, `listIssues`, `getPRReviews`; auth resolved per-call via `gh auth token` (zero persistence per AC-017); ETag cache implemented; 304 short-circuits; backoff on 403 rate limit
+  - Links: plan.md § Tech stack; spec.md AC-017 (no token persistence), § Security
+  - Dependencies: #(M2.1)
+  - Touch: `apps/kerrigan-dashboard/src/lib/github.ts`, sibling test
+  - Tests: Vitest unit with `nock`-mocked HTTP (10+ cases); explicit assertion that no token is written to disk
+
+- [ ] Task M2.4: Portfolio view + project card component
+  - Done when: route `/` renders the card grid with real data via M2.2 + M2.3; card shows project name, repo count, last-merged-PR timestamp, basic counts; matches pre-vis design tokens; offline indicator (AC-014) when GitHub unreachable; first paint <1s (AC-001)
+  - Links: spec.md AC-001, AC-002, AC-014; plan.md M2
+  - Dependencies: #(M2.2), #(M2.3)
+  - Touch: `apps/kerrigan-dashboard/src/routes/portfolio/**`, `apps/kerrigan-dashboard/src/components/ProjectCard/**`
+  - Tests: Vitest component tests; Playwright E2E asserting first paint + card render
+
+- [ ] Task M2.5: CI `dashboard-build.yml` workflow (Win/macOS/Linux)
+  - Done when: `.github/workflows/dashboard-build.yml` builds the Tauri app on all three OSes; lint + Vitest + smoke pass; artifact uploaded on tag; required-check name documented in playbooks
+  - Links: plan.md § CI / build
+  - Dependencies: #(M2.1)
+  - Touch: `.github/workflows/dashboard-build.yml`, `scripts/smoke.ps1`, `scripts/smoke.sh`
+  - Tests: workflow green on a draft PR; verify check shows up in branch protection list
+
+---
+
+## Milestone 3: Project detail + DAG (wave-3, parallel with M4)
+
+- [ ] Task M3.1: Plan markdown parser (`lib/plan-parser.ts`)
+  - Done when: parser extracts stages from H2/H3 headings; supports optional YAML frontmatter declaring stage dependencies (`dependencies: [stage-id, ...]`); returns typed graph (`{nodes, edges}`); handles malformed input gracefully with structured errors
+  - Links: spec.md OQ-001 (resolves); plan.md M3
+  - Dependencies: none (can start in parallel with M2 finish if needed)
+  - Touch: `apps/kerrigan-dashboard/src/lib/plan-parser.ts` + test
+  - Tests: Vitest unit (15+ cases incl. nested headings, missing frontmatter, circular deps detected, empty plan)
+
+- [ ] Task M3.2: Status taxonomy + derivation
+  - Done when: `lib/status.ts` maps a stage's associated PRs/issues/blocks to one of `{not-started, in-progress, needs-review, blocked, complete}`; rules documented in module header comment; consumes M2.3 GitHub data + M3.1 stage→issue links
+  - Links: plan.md M3; spec.md AC-005
+  - Dependencies: #(M3.1), #(M2.3)
+  - Touch: `apps/kerrigan-dashboard/src/lib/status.ts` + test
+  - Tests: Vitest table-driven (12+ cases covering each status + multi-repo aggregation per AC-016)
+
+- [ ] Task M3.3: React Flow DAG canvas + auto-layout
+  - Done when: project detail route renders the parsed graph as a React Flow canvas with dagre auto-layout; custom stage nodes show name + status color; pan/zoom works; interactive in <1s for ≤200 nodes
+  - Links: spec.md AC-003, AC-004, AC-005; plan.md M3
+  - Dependencies: #(M3.1), #(M3.2)
+  - Touch: `apps/kerrigan-dashboard/src/routes/project/**`, `apps/kerrigan-dashboard/src/components/Dag/**`
+  - Tests: Playwright E2E navigating portfolio → project; visual-regression on three reference plans
+
+- [ ] Task M3.4: Plan editor pane (read-only Tiptap)
+  - Done when: project detail layout has a left pane showing the project's plan as rendered markdown via Tiptap (read-only); scroll-syncs roughly with DAG selection
+  - Links: plan.md M3; spec.md AC-008 (prepares for M6)
+  - Dependencies: #(M3.3)
+  - Touch: `apps/kerrigan-dashboard/src/components/PlanEditor/**`
+  - Tests: Vitest component test; Playwright assertion that pane renders
+
+---
+
+## Milestone 4: Chat pane (wave-3, parallel with M3)
+
+- [ ] Task M4.1: `lib/acp-client.ts` — ACP wrapper around `copilot --acp`
+  - Done when: TS module spawns `copilot --acp` subprocess, manages JSON-RPC framing, exposes `sendUserTurn(text) -> AsyncIterable<AcpEvent>`; surfaces "copilot CLI missing / too old" errors with actionable messages; clean shutdown on app close
+  - Links: plan.md M4; spec.md AC-010
+  - Dependencies: ~#(M2.1) (can scaffold against placeholder app)
+  - Touch: `apps/kerrigan-dashboard/src/lib/acp-client.ts` + test
+  - Tests: Vitest unit with a mocked ACP server (covers session lifecycle, all event types, error paths)
+
+- [ ] Task M4.2: ACP event renderers + chat pane UI
+  - Done when: right-pane chat renders `message_chunk` (streaming), `tool_call`, `tool_result`, `thought` as distinct React components; input affordance with submit + cancel; error surface for offline / missing CLI
+  - Links: plan.md M4; spec.md AC-010 (vanilla portion)
+  - Dependencies: #(M4.1)
+  - Touch: `apps/kerrigan-dashboard/src/components/Chat/**`
+  - Tests: Vitest component tests for each event type; Playwright smoke that opens chat and exchanges one message against a stub backend
+
+---
+
+## Milestone 5: Kerrigan MCP server + chat-driven actions (wave-4, parallel with M6)
+
+- [ ] Task M5.1: `tools/kerrigan-mcp/` scaffold + `kerrigan.dispatch` tool
+  - Done when: `tools/kerrigan-mcp/` is a TypeScript MCP server (Node 22) registered via stdio transport; exposes `kerrigan.dispatch` that wraps the existing dispatch flow (calls `tools/create_issues.py` or its TS equivalent); MCP integration test creates a fixture issue
+  - Links: plan.md M5; spec.md AC-010, AC-011
+  - Dependencies: #(M4.2)
+  - Touch: `tools/kerrigan-mcp/**`
+  - Tests: MCP integration test against a fixture repo (token via `gh auth token`)
+
+- [ ] Task M5.2: `kerrigan.plan-update` MCP tool
+  - Done when: tool applies a structured edit (replace stage, add stage, edit stage deps) to a project's plan.md, commits to a branch, opens a draft PR
+  - Links: plan.md M5; spec.md AC-008
+  - Dependencies: #(M5.1)
+  - Touch: `tools/kerrigan-mcp/src/tools/plan-update.ts` + test
+  - Tests: integration test against the fixture repo asserting the PR opens with the expected diff
+
+- [ ] Task M5.3: `kerrigan.block-resolve` + `kerrigan.conflict-predict` MCP tools
+  - Done when: `block-resolve` marks a block resolved in `.specify/blocks/<task>.yaml`, closes the block issue, and re-arms dependent tasks; `conflict-predict` shells out to the existing `kerrigan-conflict-predictor` over a candidate task list and returns the JSON wave map
+  - Links: plan.md M5; spec.md AC-011
+  - Dependencies: #(M5.1)
+  - Touch: `tools/kerrigan-mcp/src/tools/block-resolve.ts`, `tools/kerrigan-mcp/src/tools/conflict-predict.ts`, tests
+  - Tests: integration tests for each tool
+
+- [ ] Task M5.4: Sidecar wiring + reactive pane refresh
+  - Done when: dashboard spawns the MCP server at startup and passes it to `copilot --acp` via `--additional-mcp-config`; dashboard listens to MCP `tool-result` events over a control channel and refreshes the affected pane (plan editor reloads on `plan-update`, DAG re-renders on `dispatch` / `block-resolve`)
+  - Links: plan.md M5
+  - Dependencies: #(M5.1), #(M5.2), #(M5.3), #(M4.2)
+  - Touch: `apps/kerrigan-dashboard/src/lib/mcp-sidecar.ts`, integration glue in chat + DAG components
+  - Tests: Playwright E2E — chat dispatches via MCP and the DAG updates without reload
+
+---
+
+## Milestone 6: Plan editor (write) + git round-trip (wave-4, parallel with M5)
+
+- [ ] Task M6.1: Tiptap writable + markdown round-trip
+  - Done when: plan editor accepts edits; markdown is preserved byte-equivalent for unchanged regions on save; Ctrl-S + blur both save; undo/redo work
+  - Links: plan.md M6; spec.md AC-008
+  - Dependencies: #(M3.4)
+  - Touch: `apps/kerrigan-dashboard/src/components/PlanEditor/**`
+  - Tests: Vitest property test asserting markdown round-trip for a corpus of sample plans
+
+- [ ] Task M6.2: Branch-per-edit-session + draft PR open
+  - Done when: each editing session opens a branch `plan-edits/<timestamp>-<short-sha>`; save commits + pushes to that branch; first save in a session opens a draft PR via Octokit; subsequent saves push commits to the same branch
+  - Links: plan.md M6; spec.md AC-009
+  - Dependencies: #(M6.1), #(M2.3)
+  - Touch: `apps/kerrigan-dashboard/src/lib/plan-save.ts`
+  - Tests: integration test against a fixture repo asserting branch + PR creation
+
+- [ ] Task M6.3: Conflict detection + offline edit queue
+  - Done when: if the plan file is touched by an open PR from an `agent:go`-assigned issue, save is blocked and the conflict surfaces in the inbox preview; offline edits serialize to `~/.kerrigan/queue/` and replay on reconnect
+  - Links: plan.md M6; spec.md AC-009, AC-015
+  - Dependencies: #(M6.2)
+  - Touch: `apps/kerrigan-dashboard/src/lib/plan-conflict.ts`, `apps/kerrigan-dashboard/src/lib/plan-queue.ts`
+  - Tests: Vitest unit (conflict cases); Playwright E2E for offline → online replay
+
+---
+
+## Milestone 7: PR-flow show-stopper animation (wave-5, parallel with M8)
+
+- [ ] Task M7.1: Canvas particle system overlay
+  - Done when: lightweight canvas overlay sits on top of the React Flow DAG; emits particles from a source point to a target point; 60fps with ≤20 simultaneous particles; respects `prefers-reduced-motion` (renders static markers)
+  - Links: plan.md M7; spec.md § Show-stopper, AC-020
+  - Dependencies: #(M3.3)
+  - Touch: `apps/kerrigan-dashboard/src/components/PrFlowOverlay/**`
+  - Tests: Vitest performance harness (frame timing under load); Playwright visual diff against M1 pre-vis chosen variant
+
+- [ ] Task M7.2: PR → stage particle binding + lifecycle states
+  - Done when: open PRs render an ongoing streaming particle along the PR-node-to-stage-node edge; merged PRs trigger an absorption animation + node green pulse; closed/abandoned PRs fade their particle
+  - Links: plan.md M7; spec.md AC-006, AC-007
+  - Dependencies: #(M7.1), #(M3.2)
+  - Touch: `apps/kerrigan-dashboard/src/components/PrFlowOverlay/binding.ts`
+  - Tests: Playwright E2E driving fixture PR states; visual diff
+
+---
+
+## Milestone 8: Intervention inbox (wave-5, parallel with M7)
+
+- [ ] Task M8.1: Cross-project inbox aggregator
+  - Done when: `lib/inbox.ts` pulls open blocks, `agent:wait + capture` issues, PRs with unresolved review threads, and attestation requests from all projects in `~/.kerrigan/projects.json`; returns a typed unified feed sorted by age
+  - Links: plan.md M8; spec.md AC-012
+  - Dependencies: #(M2.3)
+  - Touch: `apps/kerrigan-dashboard/src/lib/inbox.ts` + test
+  - Tests: Vitest unit with fixture GitHub responses (12+ cases)
+
+- [ ] Task M8.2: Inbox view + per-item actions
+  - Done when: filterable inbox view (by project, type, age); per-item actions `dispatch` (sends to chat with prefilled prompt), `close with reason`, `snooze`; processes ≥10 items in ≤2 min in walkthrough
+  - Links: plan.md M8; spec.md AC-012, AC-013
+  - Dependencies: #(M8.1), #(M5.1)
+  - Touch: `apps/kerrigan-dashboard/src/routes/inbox/**`
+  - Tests: Playwright E2E walking through filter + dispatch + close
+
+- [ ] Task M8.3: Mobile-capture triage side panel
+  - Done when: clicking a `capture`-labeled item opens a side panel with the captured text and a "draft briefing" button that calls the MCP `briefing-gen` tool (or `plan-update` for "add to plan now")
+  - Links: plan.md M8; spec.md AC-013
+  - Dependencies: #(M8.2), #(M5.2)
+  - Touch: `apps/kerrigan-dashboard/src/components/CaptureTriage/**`
+  - Tests: Playwright E2E captures → triage → briefing draft
+
+---
+
+## Notes for the conductor
+
+- Re-run `kerrigan-conflict-predictor` before each wave dispatch; the `Touch` field above is authoritative for overlap detection.
+- Update issue numbers next to each `Tracked as:` line as briefings are written and issues are filed.
+- Tasks above are sized for one cloud-agent dispatch each (target ≤6h of agent wall time). If a task balloons, split it during briefing-packet drafting; do not over-stuff briefings.
+- All `Done when` conditions must map to an automated test per AGENTS.md § Testing.

--- a/specs/projects/kerrigan-dashboard/tasks.md
+++ b/specs/projects/kerrigan-dashboard/tasks.md
@@ -30,38 +30,44 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
 - [ ] Task M2.1: Tauri 2 + Vite + React + TS + Tailwind project scaffold
   - Done when: `apps/kerrigan-dashboard/` builds via `pnpm tauri build` on Windows/macOS/Linux; `pnpm dev` opens a Tauri window with a placeholder route; Tailwind 4 configured with the design tokens from M1; ESLint + Prettier + tsconfig strict pass
   - Links: plan.md § Project layout, § Tech stack; spec.md AC-001 (cold start)
-  - Dependencies: ~#288 (M1 design tokens consumed)
+  - Dependencies:
+    - ~external:M1.1 (M1 design tokens consumed)
   - Touch: `apps/kerrigan-dashboard/**`
   - Read-only: everything else
-  - Tests: smoke (`scripts/smoke.ps1`/`.sh` invokes `tauri build` and asserts artifact)
+  - Tests: Vitest scaffold sanity + a CI step in M2.5's workflow that runs `pnpm -C apps/kerrigan-dashboard tauri build` and asserts the artifact (the existing repo `scripts/smoke.*` are read-only repo-health checks today; extending them to build/launch the dashboard is owned by M2.5)
 
 - [ ] Task M2.2: `lib/projects.ts` — `~/.kerrigan/projects.json` reader + schema validator
   - Done when: TS module reads, validates (zod), and watches the file; emits typed `ProjectConfig[]`; handles missing/malformed file gracefully (returns empty + surfaces error)
-  - Links: spec.md § Multi-repo / multi-project; AC-014 (offline)
-  - Dependencies: #(M2.1)
+  - Links: spec.md scope bullet on multi-repo aggregation (`### In scope (v1)`), AC-002, AC-014, AC-016
+  - Dependencies:
+    - external:M2.1
   - Touch: `apps/kerrigan-dashboard/src/lib/projects.ts`, `apps/kerrigan-dashboard/src/lib/projects.test.ts`
   - Tests: Vitest unit (8+ cases incl. malformed JSON, missing file, schema violations, hot-reload)
 
 - [ ] Task M2.3: `lib/github.ts` — Octokit wrapper with `gh auth token` shell-out + ETag polling
   - Done when: module exposes `getRepo`, `listOpenPRs`, `listIssues`, `getPRReviews`; auth resolved per-call via `gh auth token` (zero persistence per AC-017); ETag cache implemented; 304 short-circuits; backoff on 403 rate limit
-  - Links: plan.md § Tech stack; spec.md AC-017 (no token persistence), § Security
-  - Dependencies: #(M2.1)
+  - Links: plan.md § Tech stack, plan.md § Security; spec.md AC-017 (no token persistence)
+  - Dependencies:
+    - external:M2.1
   - Touch: `apps/kerrigan-dashboard/src/lib/github.ts`, sibling test
   - Tests: Vitest unit with `nock`-mocked HTTP (10+ cases); explicit assertion that no token is written to disk
 
 - [ ] Task M2.4: Portfolio view + project card component
-  - Done when: route `/` renders the card grid with real data via M2.2 + M2.3; card shows project name, repo count, last-merged-PR timestamp, basic counts; matches pre-vis design tokens; offline indicator (AC-014) when GitHub unreachable; first paint <1s (AC-001)
+  - Done when: route `/` renders the card grid with real data via M2.2 + M2.3; each card displays exactly the fields required by AC-002 — project name, repo count, current wave, block count, intervention count, last-PR-merged timestamp; matches pre-vis design tokens; offline indicator (AC-014) when GitHub unreachable; first paint <1s (AC-001)
   - Links: spec.md AC-001, AC-002, AC-014; plan.md M2
-  - Dependencies: #(M2.2), #(M2.3)
+  - Dependencies:
+    - external:M2.2
+    - external:M2.3
   - Touch: `apps/kerrigan-dashboard/src/routes/portfolio/**`, `apps/kerrigan-dashboard/src/components/ProjectCard/**`
   - Tests: Vitest component tests; Playwright E2E asserting first paint + card render
 
-- [ ] Task M2.5: CI `dashboard-build.yml` workflow (Win/macOS/Linux)
-  - Done when: `.github/workflows/dashboard-build.yml` builds the Tauri app on all three OSes; lint + Vitest + smoke pass; artifact uploaded on tag; required-check name documented in playbooks
+- [ ] Task M2.5: CI `dashboard-build.yml` workflow (Win/macOS/Linux) + extend smoke scripts
+  - Done when: `.github/workflows/dashboard-build.yml` builds the Tauri app on all three OSes; lint + Vitest pass; `scripts/smoke.ps1` / `scripts/smoke.sh` extended (behind an opt-in flag or detection of `apps/kerrigan-dashboard/`) to run `pnpm -C apps/kerrigan-dashboard tauri build` and assert the artifact exists; the matrix invokes the extended smoke; artifact uploaded on tag; required-check name documented in playbooks
   - Links: plan.md § CI / build
-  - Dependencies: #(M2.1)
+  - Dependencies:
+    - external:M2.1
   - Touch: `.github/workflows/dashboard-build.yml`, `scripts/smoke.ps1`, `scripts/smoke.sh`
-  - Tests: workflow green on a draft PR; verify check shows up in branch protection list
+  - Tests: workflow green on a draft PR; verify check shows up in branch protection list; extended smoke produces an artifact on each OS
 
 ---
 
@@ -75,25 +81,30 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
   - Tests: Vitest unit (15+ cases incl. nested headings, missing frontmatter, circular deps detected, empty plan)
 
 - [ ] Task M3.2: Status taxonomy + derivation
-  - Done when: `lib/status.ts` maps a stage's associated PRs/issues/blocks to one of `{not-started, in-progress, needs-review, blocked, complete}`; rules documented in module header comment; consumes M2.3 GitHub data + M3.1 stage→issue links
+  - Done when: `lib/status.ts` maps a stage's associated PRs/issues/blocks to one of the spec AC-005 statuses — `planned, dispatched, in-review, blocked, needs-attestation, needs-human-test, merged`; rules documented in module header comment; consumes M2.3 GitHub data + M3.1 stage→issue links
   - Links: plan.md M3; spec.md AC-005
-  - Dependencies: #(M3.1), #(M2.3)
+  - Dependencies:
+    - external:M3.1
+    - external:M2.3
   - Touch: `apps/kerrigan-dashboard/src/lib/status.ts` + test
-  - Tests: Vitest table-driven (12+ cases covering each status + multi-repo aggregation per AC-016)
+  - Tests: Vitest table-driven (one case per status from AC-005 + multi-repo aggregation per AC-016)
 
 - [ ] Task M3.3: React Flow DAG canvas + auto-layout
   - Done when: project detail route renders the parsed graph as a React Flow canvas with dagre auto-layout; custom stage nodes show name + status color; pan/zoom works; interactive in <1s for ≤200 nodes
   - Links: spec.md AC-003, AC-004, AC-005; plan.md M3
-  - Dependencies: #(M3.1), #(M3.2)
+  - Dependencies:
+    - external:M3.1
+    - external:M3.2
   - Touch: `apps/kerrigan-dashboard/src/routes/project/**`, `apps/kerrigan-dashboard/src/components/Dag/**`
   - Tests: Playwright E2E navigating portfolio → project; visual-regression on three reference plans
 
 - [ ] Task M3.4: Plan editor pane (read-only Tiptap)
-  - Done when: project detail layout has a left pane showing the project's plan as rendered markdown via Tiptap (read-only); scroll-syncs roughly with DAG selection
+  - Done when: project detail layout has a left pane showing the project's plan as rendered markdown via Tiptap (read-only); selecting a node in the DAG scrolls the PlanEditor so the corresponding stage heading is visible (Playwright asserts `heading.isVisibleInViewport()` within 250ms of click)
   - Links: plan.md M3; spec.md AC-008 (prepares for M6)
-  - Dependencies: #(M3.3)
+  - Dependencies:
+    - external:M3.3
   - Touch: `apps/kerrigan-dashboard/src/components/PlanEditor/**`
-  - Tests: Vitest component test; Playwright assertion that pane renders
+  - Tests: Vitest component test; Playwright assertion that pane renders and that the click→scroll behavior fires
 
 ---
 
@@ -102,14 +113,16 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
 - [ ] Task M4.1: `lib/acp-client.ts` — ACP wrapper around `copilot --acp`
   - Done when: TS module spawns `copilot --acp` subprocess, manages JSON-RPC framing, exposes `sendUserTurn(text) -> AsyncIterable<AcpEvent>`; surfaces "copilot CLI missing / too old" errors with actionable messages; clean shutdown on app close
   - Links: plan.md M4; spec.md AC-010
-  - Dependencies: ~#(M2.1) (can scaffold against placeholder app)
+  - Dependencies:
+    - ~external:M2.1 (can scaffold against placeholder app)
   - Touch: `apps/kerrigan-dashboard/src/lib/acp-client.ts` + test
   - Tests: Vitest unit with a mocked ACP server (covers session lifecycle, all event types, error paths)
 
 - [ ] Task M4.2: ACP event renderers + chat pane UI
   - Done when: right-pane chat renders `message_chunk` (streaming), `tool_call`, `tool_result`, `thought` as distinct React components; input affordance with submit + cancel; error surface for offline / missing CLI
   - Links: plan.md M4; spec.md AC-010 (vanilla portion)
-  - Dependencies: #(M4.1)
+  - Dependencies:
+    - external:M4.1
   - Touch: `apps/kerrigan-dashboard/src/components/Chat/**`
   - Tests: Vitest component tests for each event type; Playwright smoke that opens chat and exchanges one message against a stub backend
 
@@ -120,28 +133,35 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
 - [ ] Task M5.1: `tools/kerrigan-mcp/` scaffold + `kerrigan.dispatch` tool
   - Done when: `tools/kerrigan-mcp/` is a TypeScript MCP server (Node 22) registered via stdio transport; exposes `kerrigan.dispatch` that wraps the existing dispatch flow (calls `tools/create_issues.py` or its TS equivalent); MCP integration test creates a fixture issue
   - Links: plan.md M5; spec.md AC-010, AC-011
-  - Dependencies: #(M4.2)
+  - Dependencies:
+    - external:M4.2
   - Touch: `tools/kerrigan-mcp/**`
   - Tests: MCP integration test against a fixture repo (token via `gh auth token`)
 
 - [ ] Task M5.2: `kerrigan.plan-update` MCP tool
   - Done when: tool applies a structured edit (replace stage, add stage, edit stage deps) to a project's plan.md, commits to a branch, opens a draft PR
   - Links: plan.md M5; spec.md AC-008
-  - Dependencies: #(M5.1)
+  - Dependencies:
+    - external:M5.1
   - Touch: `tools/kerrigan-mcp/src/tools/plan-update.ts` + test
   - Tests: integration test against the fixture repo asserting the PR opens with the expected diff
 
 - [ ] Task M5.3: `kerrigan.block-resolve` + `kerrigan.conflict-predict` MCP tools
   - Done when: `block-resolve` marks a block resolved in `.specify/blocks/<task>.yaml`, closes the block issue, and re-arms dependent tasks; `conflict-predict` shells out to the existing `kerrigan-conflict-predictor` over a candidate task list and returns the JSON wave map
   - Links: plan.md M5; spec.md AC-011
-  - Dependencies: #(M5.1)
+  - Dependencies:
+    - external:M5.1
   - Touch: `tools/kerrigan-mcp/src/tools/block-resolve.ts`, `tools/kerrigan-mcp/src/tools/conflict-predict.ts`, tests
   - Tests: integration tests for each tool
 
 - [ ] Task M5.4: Sidecar wiring + reactive pane refresh
   - Done when: dashboard spawns the MCP server at startup and passes it to `copilot --acp` via `--additional-mcp-config`; dashboard listens to MCP `tool-result` events over a control channel and refreshes the affected pane (plan editor reloads on `plan-update`, DAG re-renders on `dispatch` / `block-resolve`)
   - Links: plan.md M5
-  - Dependencies: #(M5.1), #(M5.2), #(M5.3), #(M4.2)
+  - Dependencies:
+    - external:M5.1
+    - external:M5.2
+    - external:M5.3
+    - external:M4.2
   - Touch: `apps/kerrigan-dashboard/src/lib/mcp-sidecar.ts`, integration glue in chat + DAG components
   - Tests: Playwright E2E — chat dispatches via MCP and the DAG updates without reload
 
@@ -152,21 +172,25 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
 - [ ] Task M6.1: Tiptap writable + markdown round-trip
   - Done when: plan editor accepts edits; markdown is preserved byte-equivalent for unchanged regions on save; Ctrl-S + blur both save; undo/redo work
   - Links: plan.md M6; spec.md AC-008
-  - Dependencies: #(M3.4)
+  - Dependencies:
+    - external:M3.4
   - Touch: `apps/kerrigan-dashboard/src/components/PlanEditor/**`
   - Tests: Vitest property test asserting markdown round-trip for a corpus of sample plans
 
 - [ ] Task M6.2: Branch-per-edit-session + draft PR open
   - Done when: each editing session opens a branch `plan-edits/<timestamp>-<short-sha>`; save commits + pushes to that branch; first save in a session opens a draft PR via Octokit; subsequent saves push commits to the same branch
   - Links: plan.md M6; spec.md AC-009
-  - Dependencies: #(M6.1), #(M2.3)
+  - Dependencies:
+    - external:M6.1
+    - external:M2.3
   - Touch: `apps/kerrigan-dashboard/src/lib/plan-save.ts`
   - Tests: integration test against a fixture repo asserting branch + PR creation
 
 - [ ] Task M6.3: Conflict detection + offline edit queue
   - Done when: if the plan file is touched by an open PR from an `agent:go`-assigned issue, save is blocked and the conflict surfaces in the inbox preview; offline edits serialize to `~/.kerrigan/queue/` and replay on reconnect
   - Links: plan.md M6; spec.md AC-009, AC-015
-  - Dependencies: #(M6.2)
+  - Dependencies:
+    - external:M6.2
   - Touch: `apps/kerrigan-dashboard/src/lib/plan-conflict.ts`, `apps/kerrigan-dashboard/src/lib/plan-queue.ts`
   - Tests: Vitest unit (conflict cases); Playwright E2E for offline → online replay
 
@@ -177,14 +201,17 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
 - [ ] Task M7.1: Canvas particle system overlay
   - Done when: lightweight canvas overlay sits on top of the React Flow DAG; emits particles from a source point to a target point; 60fps with ≤20 simultaneous particles; respects `prefers-reduced-motion` (renders static markers)
   - Links: plan.md M7; spec.md § Show-stopper, AC-020
-  - Dependencies: #(M3.3)
+  - Dependencies:
+    - external:M3.3
   - Touch: `apps/kerrigan-dashboard/src/components/PrFlowOverlay/**`
   - Tests: Vitest performance harness (frame timing under load); Playwright visual diff against M1 pre-vis chosen variant
 
 - [ ] Task M7.2: PR → stage particle binding + lifecycle states
   - Done when: open PRs render an ongoing streaming particle along the PR-node-to-stage-node edge; merged PRs trigger an absorption animation + node green pulse; closed/abandoned PRs fade their particle
   - Links: plan.md M7; spec.md AC-006, AC-007
-  - Dependencies: #(M7.1), #(M3.2)
+  - Dependencies:
+    - external:M7.1
+    - external:M3.2
   - Touch: `apps/kerrigan-dashboard/src/components/PrFlowOverlay/binding.ts`
   - Tests: Playwright E2E driving fixture PR states; visual diff
 
@@ -195,23 +222,28 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
 - [ ] Task M8.1: Cross-project inbox aggregator
   - Done when: `lib/inbox.ts` pulls open blocks, `agent:wait + capture` issues, PRs with unresolved review threads, and attestation requests from all projects in `~/.kerrigan/projects.json`; returns a typed unified feed sorted by age
   - Links: plan.md M8; spec.md AC-012
-  - Dependencies: #(M2.3)
+  - Dependencies:
+    - external:M2.3
   - Touch: `apps/kerrigan-dashboard/src/lib/inbox.ts` + test
   - Tests: Vitest unit with fixture GitHub responses (12+ cases)
 
 - [ ] Task M8.2: Inbox view + per-item actions
-  - Done when: filterable inbox view (by project, type, age); per-item actions `dispatch` (sends to chat with prefilled prompt), `close with reason`, `snooze`; processes ≥10 items in ≤2 min in walkthrough
+  - Done when: filterable inbox view (by project, type, age); per-item actions `dispatch` (sends to chat with prefilled prompt), `close with reason`, `snooze` all wired and assertable in Playwright; the "process ≥10 items in ≤2 min" target is a **manual walkthrough metric** (SM-001/SM-002 in spec.md) measured at M8 sign-off, not an automated CI gate
   - Links: plan.md M8; spec.md AC-012, AC-013
-  - Dependencies: #(M8.1), #(M5.1)
+  - Dependencies:
+    - external:M8.1
+    - external:M5.1
   - Touch: `apps/kerrigan-dashboard/src/routes/inbox/**`
-  - Tests: Playwright E2E walking through filter + dispatch + close
+  - Tests: Playwright E2E walking through filter + dispatch + close (automated gate); manual walkthrough capturing item-throughput at M8 sign-off (manual gate, recorded in PR description)
 
 - [ ] Task M8.3: Mobile-capture triage side panel
-  - Done when: clicking a `capture`-labeled item opens a side panel with the captured text and a "draft briefing" button that calls the MCP `briefing-gen` tool (or `plan-update` for "add to plan now")
-  - Links: plan.md M8; spec.md AC-013
-  - Dependencies: #(M8.2), #(M5.2)
+  - Done when: clicking a `capture`-labeled item opens a side panel with the captured text and a "draft briefing" button that calls the MCP `kerrigan.plan-update` tool to insert a briefing-shaped block into a draft PR on the target project (briefing drafting is in v1 scope via `plan-update`; a dedicated `kerrigan.briefing-gen` tool is explicitly out of v1 per spec AC-011)
+  - Links: plan.md M8; spec.md AC-013, AC-011
+  - Dependencies:
+    - external:M8.2
+    - external:M5.2
   - Touch: `apps/kerrigan-dashboard/src/components/CaptureTriage/**`
-  - Tests: Playwright E2E captures → triage → briefing draft
+  - Tests: Playwright E2E captures → triage → draft PR via `plan-update`
 
 ---
 

--- a/specs/projects/kerrigan-dashboard/test-plan.md
+++ b/specs/projects/kerrigan-dashboard/test-plan.md
@@ -6,7 +6,7 @@
 - **Component (Vitest + React Testing Library)** — `apps/kerrigan-dashboard/src/components/**`. Renderers for ACP events, ProjectCard, InboxItem, PlanEditor in read-only and writable modes.
 - **Integration** — `tools/kerrigan-mcp/test/**` exercising the MCP server against a fixture GitHub repo (authenticated via the developer's `gh auth token`; in CI via a scoped PAT secret). Covers each tool end-to-end.
 - **E2E (Playwright)** — `apps/kerrigan-dashboard/tests/e2e/**` driving the Tauri app via Playwright's Tauri driver. Critical flows: portfolio → project → chat → dispatch; plan edit → save → draft PR; offline indicator; inbox triage.
-- **Smoke** — `scripts/smoke.ps1` / `.sh` runs `tauri build` on the current OS, launches the binary, asserts the window opens, asserts one successful GitHub API call is made. Required for PR merge per [AGENTS.md](../../../AGENTS.md).
+- **Smoke** — today, `scripts/smoke.ps1` / `.sh` perform read-only repo health checks only (no Tauri/Node build). Task M2.5 extends them so that when `apps/kerrigan-dashboard/` exists they additionally run `pnpm -C apps/kerrigan-dashboard tauri build`, assert the artifact, and (on CI OSes where binary launch is feasible) launch and assert one successful GitHub API call. The extended smoke gates PR merge per [AGENTS.md](../../../AGENTS.md).
 - **Pre-vis static checks (Python)** — `tests/projects/kerrigan_dashboard/test_previs_*.py`. Validate the M1 deliverable's structure, color/type/motion budgets, and responsive breakpoints before any production UI is dispatched.
 
 ## Tooling

--- a/specs/projects/kerrigan-dashboard/test-plan.md
+++ b/specs/projects/kerrigan-dashboard/test-plan.md
@@ -1,0 +1,44 @@
+# Test plan: kerrigan-dashboard
+
+## Levels
+
+- **Unit (Vitest)** — pure logic in `apps/kerrigan-dashboard/src/lib/**` and `tools/kerrigan-mcp/src/**`. Parsers, status derivation, ACP framing, MCP tool handlers, plan-queue serialization. Target: ≥80% line coverage on these modules.
+- **Component (Vitest + React Testing Library)** — `apps/kerrigan-dashboard/src/components/**`. Renderers for ACP events, ProjectCard, InboxItem, PlanEditor in read-only and writable modes.
+- **Integration** — `tools/kerrigan-mcp/test/**` exercising the MCP server against a fixture GitHub repo (authenticated via the developer's `gh auth token`; in CI via a scoped PAT secret). Covers each tool end-to-end.
+- **E2E (Playwright)** — `apps/kerrigan-dashboard/tests/e2e/**` driving the Tauri app via Playwright's Tauri driver. Critical flows: portfolio → project → chat → dispatch; plan edit → save → draft PR; offline indicator; inbox triage.
+- **Smoke** — `scripts/smoke.ps1` / `.sh` runs `tauri build` on the current OS, launches the binary, asserts the window opens, asserts one successful GitHub API call is made. Required for PR merge per [AGENTS.md](../../../AGENTS.md).
+- **Pre-vis static checks (Python)** — `tests/projects/kerrigan_dashboard/test_previs_*.py`. Validate the M1 deliverable's structure, color/type/motion budgets, and responsive breakpoints before any production UI is dispatched.
+
+## Tooling
+
+- **Test runner**: Vitest (frontend + sidecar), Playwright (E2E), pytest (cross-cutting Python checks already in repo).
+- **Coverage**: c8 via Vitest's `--coverage` flag; HTML report archived as CI artifact; PR comment via `vitest-coverage-report-action`.
+- **Linting/typing**: ESLint + `typescript --noEmit` in strict mode; Prettier for format; Rust `cargo clippy` + `cargo fmt` for the Tauri shell.
+- **Fixtures**: a small fixture GitHub repo (`Kixantrix/kerrigan-dashboard-fixtures`, to be created) holds canned PRs, issues, blocks, and plan files used by integration and E2E suites.
+- **Mocking**: `nock` for HTTP at the Octokit layer; a tiny in-process ACP server stub for `acp-client.test.ts`.
+- **CI workflow**: new `.github/workflows/dashboard-build.yml` matrices on `{windows-latest, macos-14, ubuntu-22.04}` × `{lint, vitest, smoke}`; required for merge once introduced in Task M2.5.
+
+## Risk areas / focus
+
+| Risk | Focus | Mitigation tests |
+|---|---|---|
+| ACP stream format drift across Copilot CLI versions | `lib/acp-client.ts` | Pinned CLI version in CI; a contract test that runs `copilot --version` and asserts the minimum; mock ACP server covers every event type. |
+| GitHub API rate limits | `lib/github.ts` | Integration test asserts ETag round-trip + adaptive backoff under simulated 403. |
+| Markdown round-trip fidelity loss | `components/PlanEditor` | Property test (`fast-check`) over a corpus of sample plans asserting byte-equivalent output for unchanged regions. |
+| Tauri allowlist regressions opening attack surface | `src-tauri/tauri.conf.json` | A unit test parses the config and asserts a denylist of forbidden scopes (e.g., `shell.execute` with `args: "*"`). |
+| Show-stopper animation perf below 60fps | `components/PrFlowOverlay` | Vitest perf harness measures frame time with synthetic 20 particles; fails if median exceeds 16ms. |
+| No-credential-persistence assertion drifts | `lib/github.ts` + repo-wide | Post-shutdown scan of `~/.kerrigan/` and the Tauri app data directory for any string matching `ghp_`, `github_pat_`, or `gho_`. Runs in CI E2E job. |
+| Plan-edit / cloud-agent file conflict | `lib/plan-conflict.ts` | Integration test simulates a cloud-agent PR touching the same file mid-edit; asserts save is blocked and surfaces an inbox item. |
+| Cross-platform smoke failures | `scripts/smoke.ps1` / `.sh` | Matrix CI on Windows/macOS/Linux is the test; visual artifact on failure (screenshot of the launched window). |
+
+## Coverage gates
+
+- Block PR merge if `apps/kerrigan-dashboard/src/lib/**` coverage <80%.
+- Block PR merge if any AC's mapped test in [`acceptance-tests.md`](./acceptance-tests.md) is missing or skipped.
+- Block PR merge if smoke fails on any of the three OSes in the matrix.
+
+## Out-of-scope tests
+
+- Visual regression beyond the show-stopper variant chosen at M1. We rely on the design budget linter (`tests/projects/kerrigan_dashboard/test_previs_budgets.py`) and human review.
+- Cross-version Copilot CLI compatibility beyond the pinned minimum. Surfacing a clear "upgrade Copilot CLI" message is acceptable.
+- Load testing — single-user local app; not relevant.


### PR DESCRIPTION
﻿Adds M2-M8 task decomposition for kerrigan-dashboard (23 dispatchable tasks across 4 waves), plus the full required artifact set per 	ools/validators/check_artifacts.py: cceptance-tests.md, rchitecture.md, 	est-plan.md, unbook.md, cost-plan.md.

## Task count
23 tasks for M2-M8: M2.1-M2.5 (5) + M3.1-M3.4 (4) + M4.1-M4.2 (2) + M5.1-M5.4 (4) + M6.1-M6.3 (3) + M7.1-M7.2 (2) + M8.1-M8.3 (3). M1.1 is listed for reference but is in flight as #288.

## Wave structure
- **wave-2**: M2 (Tauri skeleton + portfolio)
- **wave-3**: M3 + M4 parallel
- **wave-4**: M5 + M6 parallel
- **wave-5**: M7 + M8 parallel

## Review pass
First review by Copilot caught 18 internal-consistency issues (mismatched smoke descriptions, status taxonomy conflicts, broken section anchors, MCP tool list inconsistency, ambiguous Done-when, references to a nonexistent test file). All addressed in commit `0438713`.
