### PR TITLE
chore(harness): dispatch friction fixes (issue wrapper, stderr false-fail, cloud rules)

### DIFF
--- a/.github/agents/cloud.md
+++ b/.github/agents/cloud.md
@@ -25,6 +25,7 @@ blocks_on:
   - missing_secret
   - local_required
   - out_of_budget
+  - merge_conflict_unresolvable
 ---
 
 # cloud — executor
@@ -47,9 +48,11 @@ Run in this order, and do not open a PR until all required checks are green:
 1. **Run unit + integration tests** for the slice.
 2. **Run smoke test** (`scripts/smoke.sh`) when present for the project.
 3. **Run lint/type checks** required by the project.
-4. **Handle failures in scope first.** If any check fails, attempt fixes that stay inside briefing scope.
-5. **For any AC declared `environment: local-attested-*`, do NOT mark it complete.** Add `pending-attestation: <ac-id>` to the PR body and continue with other ACs.
-6. **If still failing and unfixable in scope, emit a block and stop.** Use the self-test failure block template below. Do not open a PR.
+4. **Verify dependency manifests match imports.** If your tests `import X` from a third-party package, `X` (or its distribution) must be in the project's dependency manifest (`requirements.txt`, `package.json`, `Cargo.toml`, etc.) on the same branch. Cloud CI runs in a clean container — missing manifest entries fail there even if your local container has the package cached. (Named cautionary case: 2026-05-27 PR #289 pushed a test importing `bs4` without adding `beautifulsoup4` to `requirements.txt`.)
+5. **Rebase on the base branch before pushing.** Run `git fetch origin && git rebase origin/<base>` (or `git merge origin/<base>` if rebase is risky for your slice). If conflicts arise, attempt resolution in scope. If the conflict touches files outside your briefing's `Touch` list or you can't determine the correct resolution, **emit a `merge_conflict_unresolvable` block and stop** — do not guess, do not force-push, do not silently abandon your branch.
+6. **Handle failures in scope first.** If any check fails, attempt fixes that stay inside briefing scope.
+7. **For any AC declared `environment: local-attested-*`, do NOT mark it complete.** Add `pending-attestation: <ac-id>` to the PR body and continue with other ACs.
+8. **If still failing and unfixable in scope, emit a block and stop.** Use the self-test failure block template below. Do not open a PR.
 
 ## What you don't do
 

--- a/.github/agents/kerrigan.md
+++ b/.github/agents/kerrigan.md
@@ -221,7 +221,13 @@ The merge is gated by `required_review_thread_resolution: true` in branch protec
 
 ### Dispatching
 
-**Never** use inline `gh issue create` with PowerShell heredocs — heredoc termination is ambiguous and the create command often fires twice creating duplicate issues + PRs. Use `tools/create_issues.py` or write the body to a temp file: `Set-Content -Path body.md -Value $body; gh issue create --body-file body.md`.
+**Never** use inline `gh issue create` with PowerShell heredocs — heredoc termination is ambiguous and the create command often fires twice creating duplicate issues + PRs (2026-05-27 #293/#295 incident). Use one of:
+
+- `tools/new-issue.ps1 -Title "..." -BodyFile body.md -Label agent:go -Assignee copilot` (preferred for single issues)
+- `tools/create_issues.py` (preferred for batch dispatch from `tasks.md`)
+- Last resort: `Set-Content -Encoding utf8 -NoNewline -Path body.md -Value $body` followed by `gh issue create --body-file body.md` as **separate** statements (never chained with `;` to a heredoc).
+
+Always write the body as UTF-8 (no BOM) — default `Set-Content` encoding produces mojibake (`ΓÇö` for `—`) in issue bodies.
 
 The review chain: cloud self-test → CI → Copilot review → **cloud agent addresses feedback (kerrigan re-dispatches via `@copilot` comment)** → conversation resolution + CI green → auto-merge.
 

--- a/.github/agents/kerrigan.md
+++ b/.github/agents/kerrigan.md
@@ -178,6 +178,8 @@ Use these helper scripts during the PR dispatch/review/merge loop:
 
 ### When Copilot finishes (signal: `[WIP]` removed from PR title — Copilot can't mark PRs ready itself)
 
+**Pre-flight (MANDATORY before any promotion step)**: verify the PR actually delivers work. Run `gh pr view <N> --json files,commits -q '{files:[.files[].path]|length, commits:[.commits[].messageHeadline]}'`. If `files` is `0` OR commits are only `Initial plan` / merge commits, **DO NOT PROMOTE** — the cloud agent stalled and prematurely cleared `[WIP]`. Instead: close the PR, reopen the issue with a comment instructing not to flip `[WIP]` until the done-when checks pass. The 2026-05-27 #294 incident (empty M2.1 PR auto-merged to main) is the named cautionary case.
+
 Promote the PR in this exact order. Order matters because auto-merge can race ahead of review requests:
 
 1. `gh pr ready <N>` — flip draft → ready.

--- a/tools/new-issue.ps1
+++ b/tools/new-issue.ps1
@@ -1,0 +1,82 @@
+#!/usr/bin/env pwsh
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Create a single GitHub issue from a body file, avoiding the PowerShell heredoc footgun.
+
+.DESCRIPTION
+    Inline `gh issue create --body "@'...'@"` with multi-line PowerShell heredocs has fired
+    `gh issue create` twice in this repo (issues #293+#295 / PRs #294+#296 incident,
+    2026-05-27), creating duplicate issues and duplicate cloud-agent PRs.
+
+    This wrapper always reads the body from a file written as UTF-8 (no BOM), passes it via
+    --body-file, and ensures exactly one invocation. Use this in place of any inline
+    `gh issue create --body "..."` with multi-line content.
+
+.PARAMETER Title
+    Issue title.
+
+.PARAMETER BodyFile
+    Path to a UTF-8 file containing the issue body. Required.
+
+.PARAMETER Label
+    Zero or more labels to apply.
+
+.PARAMETER Assignee
+    Optional assignee handle (e.g. 'copilot' or a username).
+
+.PARAMETER Milestone
+    Optional milestone name.
+
+.PARAMETER DryRun
+    Print the planned gh command without executing it.
+
+.EXAMPLE
+    .\tools\new-issue.ps1 -Title "Wire up X" -BodyFile .specify/briefings/x.md -Label agent:go -Assignee copilot
+
+.EXAMPLE
+    Set-Content -Encoding utf8 -NoNewline -Path body.md -Value $body
+    .\tools\new-issue.ps1 -Title "Fix Y" -BodyFile body.md -Label agent:go,bug
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Title,
+    [Parameter(Mandatory = $true)]
+    [string]$BodyFile,
+    [string[]]$Label,
+    [string]$Assignee,
+    [string]$Milestone,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $BodyFile)) {
+    Write-Error "Body file not found: $BodyFile"
+    exit 1
+}
+
+$args = @('issue', 'create', '--title', $Title, '--body-file', $BodyFile)
+if ($Label) {
+    foreach ($l in $Label) {
+        $args += @('--label', $l)
+    }
+}
+if ($Assignee) {
+    $args += @('--assignee', $Assignee)
+}
+if ($Milestone) {
+    $args += @('--milestone', $Milestone)
+}
+
+if ($DryRun) {
+    Write-Host "[dry-run] gh $($args -join ' ')"
+    exit 0
+}
+
+& gh @args
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "gh issue create failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}

--- a/tools/pr-promote.ps1
+++ b/tools/pr-promote.ps1
@@ -93,7 +93,8 @@ if (-not (Invoke-Step -Label "Ready PR #$PrNumber" -ContinueOnFailure -Command {
     if ($DryRun) {
         Write-Host "[OK] [dry-run] gh pr ready $PrNumber"
     } else {
-        gh pr ready $PrNumber | Out-Null
+        # gh writes its success confirmation to stderr; redirect so $ErrorActionPreference='Stop' doesn't treat it as a failure.
+        gh pr ready $PrNumber 2>&1 | Out-Null
     }
 })) {
     exit 1
@@ -103,7 +104,7 @@ if (-not (Invoke-Step -Label "Update branch for PR #$PrNumber" -Command {
     if ($DryRun) {
         Write-Host "[OK] [dry-run] gh pr update-branch $PrNumber"
     } else {
-        gh pr update-branch $PrNumber | Out-Null
+        gh pr update-branch $PrNumber 2>&1 | Out-Null
     }
 })) {
     exit 1


### PR DESCRIPTION
## Summary

Three friction-points from the 2026-05-27 dispatch incident, encoded as small harness fixes. Stacks on top of #298 (pre-flight check) — will rebase cleanly after #298 merges.

## Changes

### `tools/new-issue.ps1` (new)
Single-issue dispatch wrapper that always reads body from a file (`--body-file`). Eliminates the PowerShell heredoc footgun that fired `gh issue create` twice on 2026-05-27, creating duplicate issues #293+#295 and duplicate PRs #294+#296. Use this in place of any inline `gh issue create --body "..."` with multi-line content.

### `tools/pr-promote.ps1` (fix)
`gh pr ready` and `gh pr update-branch` write their success banners to **stderr**. With `$ErrorActionPreference = 'Stop'`, PowerShell converted those stderr writes into terminating errors, which `Invoke-Step` caught and reported as `[FAIL]` even though the underlying gh commands succeeded. Fix: redirect `2>&1` so success banners flow through stdout.

### `.github/agents/cloud.md` (rule)
Two new self-verification rules:
- **Dep manifest must match imports.** If a test imports `bs4`, `beautifulsoup4` must be in `requirements.txt` *on the same branch*. Cloud CI runs in clean containers — missing manifest entries fail there even when the agent's local container has the package cached. Named cautionary case: 2026-05-27 PR #289 pushed a test importing `bs4` without updating `requirements.txt`.
- **Rebase + conflict block.** Cloud agent must `git fetch && git rebase origin/<base>` before pushing. If conflicts touch files outside the briefing's `Touch` list or can't be resolved confidently, emit a new `merge_conflict_unresolvable` block and stop. Previously the agent failed silently — PR #289 (M1.1 redispatch) needed conductor-side conflict resolution because the cloud agent had forked from older main and never reconciled.

### `.github/agents/kerrigan.md` (doc)
Updates the Dispatch subsection to point at `tools/new-issue.ps1` as the preferred single-issue path, calls out UTF-8 no-BOM encoding to prevent `ΓÇö`-style mojibake in issue bodies, and removes the misleading inline heredoc example.

## Note on `[WIP]`

A correction worth flagging: the `[WIP]` prefix in cloud-agent PR titles is **Copilot's own signal** — the cloud agent decides when to flip it. The reopen comment on #293 wrongly instructed the agent not to flip `[WIP]`; that's been retracted. The actual defense against premature flips is the mandatory pre-flight diff check landed in #298.

## Test plan

- [ ] `tools/new-issue.ps1 -DryRun -Title test -BodyFile README.md -Label agent:go` prints the planned command without executing
- [ ] `tools/pr-promote.ps1 <some-draft-pr> -DryRun` runs through all four steps with `[OK]` (no false `[FAIL]`)
- [ ] CI green (no Python/JS changes, validators unaffected)

## Stacking

This branch is based on `chore/promote-preflight` (#298). After #298 merges, this PR will auto-update against `main` cleanly.
