### PR TITLE
fix: bind threadId to local in pr-resolve-threads.ps1

### DIFF
--- a/tests/test_pr_loop_helpers.py
+++ b/tests/test_pr_loop_helpers.py
@@ -37,6 +37,16 @@ def test_pr_resolve_threads_has_required_switches() -> None:
     assert "resolveReviewThread" in content
 
 
+def test_pr_resolve_threads_binds_thread_id_to_local() -> None:
+    # Regression: `-f threadId=$thread.id` makes PowerShell stringify $thread
+    # (its type name) and append literal ".id", sending a garbage thread id so
+    # the resolve silently no-ops. The property must be bound to a local first.
+    content = _read("tools/pr-resolve-threads.ps1")
+    assert "threadId=$thread.id" not in content
+    assert "$threadId = $thread.id" in content
+    assert "threadId=$threadId" in content
+
+
 def test_pr_rerun_pending_filters_by_status() -> None:
     content = _read("tools/pr-rerun-pending.ps1")
     for token in (".SYNOPSIS", ".DESCRIPTION", ".PARAMETER", ".EXAMPLE"):

--- a/tools/pr-resolve-threads.ps1
+++ b/tools/pr-resolve-threads.ps1
@@ -72,8 +72,12 @@ if ($shouldConfirm) {
 
 $mutation = 'mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }'
 foreach ($thread in $threads) {
-    gh api graphql -f query=$mutation -f threadId=$thread.id | Out-Null
-    Write-Host "Resolved thread $($thread.id)"
+    # Bind the property to a local first: passing $thread.id inline to `-f` makes
+    # PowerShell stringify $thread (its type name) and append literal text,
+    # sending a garbage id so the resolve silently no-ops.
+    $threadId = $thread.id
+    gh api graphql -f query=$mutation -f threadId=$threadId | Out-Null
+    Write-Host "Resolved thread $threadId"
 }
 
 exit 0


### PR DESCRIPTION
## What

Fix a silent no-op in `tools/pr-resolve-threads.ps1`. Passing `$thread.id` inline to `gh api graphql -f threadId=$thread.id` makes PowerShell stringify `$thread` (its type name) and append literal text, so a garbage thread id was sent and `resolveReviewThread` silently did nothing. Bind the property to a local variable first.

## Why

This helper is part of the cloud-agent PR loop. The bug forced manual GraphQL/`pr_reply_resolve.py` fallbacks every time a review thread needed resolving.

## Test

Adds `test_pr_resolve_threads_binds_thread_id_to_local` — a regression guard asserting the inline property-access form can't return. Validated the listing path with `pr-resolve-threads.ps1 <pr> -DryRun` against live PRs.
