### PR TITLE
chore(briefings): wave-2 dashboard briefings + waves.yaml + predictor-fix

### DIFF
--- a/.specify/briefings/M2.2.md
+++ b/.specify/briefings/M2.2.md
@@ -1,0 +1,54 @@
+# M2.2: `lib/projects.ts` — projects.json reader + schema validator
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 2.
+
+> **Dependency:** `external:M2.1`. Do not dispatch until the M2.1 scaffold is merged to `main`. The app shell (`apps/kerrigan-dashboard/`) must exist first.
+
+## Goal
+
+Provide a typed, validated reader for the dashboard's project registry at `~/.kerrigan/projects.json`. This is pure data-access plumbing — no GitHub calls, no UI. M2.4 (portfolio view) consumes this.
+
+## Hard constraints
+
+- **Single module:** `apps/kerrigan-dashboard/src/lib/projects.ts` (+ its test). No UI, no network.
+- **Schema-first validation.** Use `zod`. Parse, don't trust. Every field validated; malformed `projects.json` yields a typed error result, never a throw that crashes the app.
+- **Immutable returns.** Return readonly structures; never mutate the parsed object.
+- **No secrets.** This file only reads non-secret project metadata. It must not read or surface any token.
+- **Strict TS.** Must pass under the M2.1 `tsconfig` (`strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`).
+
+## Schema (from [`architecture.md`](../../specs/projects/kerrigan-dashboard/architecture.md))
+
+`~/.kerrigan/projects.json` describes the projects the dashboard tracks. Define a zod schema covering, at minimum, per-project: a stable id/name, one or more repo references (owner/repo), and the local git working-copy path(s) the app may read. Derive the TS type from the zod schema (`z.infer`) — do not hand-write a parallel interface. If the spec/architecture is ambiguous on an exact field, pick the minimal sensible shape, document it in the module header, and keep it forward-compatible (unknown keys ignored, not rejected).
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/lib/projects.ts` — new
+- `apps/kerrigan-dashboard/src/lib/projects.test.ts` — new (Vitest)
+- `apps/kerrigan-dashboard/package.json` — add `zod` dependency only
+
+## Read-only
+
+- `apps/kerrigan-dashboard/**` (existing scaffold — align to its conventions, don't restructure)
+- `specs/projects/kerrigan-dashboard/architecture.md`
+- Everything else
+
+## What "done" looks like
+
+1. `readProjects(path?)` reads + zod-validates `~/.kerrigan/projects.json` (default path; overridable for tests).
+2. Returns a discriminated result: `{ ok: true, projects }` or `{ ok: false, error }` — no uncaught throws on bad/missing input.
+3. Missing file → typed "not found" result (empty/absent registry is a valid state, not a crash).
+4. Vitest covers: valid file, malformed JSON, schema-violating file, missing file. Use a temp dir / fixture, not the real `~/.kerrigan`.
+5. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean.
+6. `kerrigan check` passes.
+
+## Out of scope
+
+- GitHub data (M2.3).
+- Rendering project cards (M2.4).
+- Writing/editing `projects.json` (read-only for now).
+- File watching / live reload of the registry.
+
+## Notes
+
+- Read via the Tauri fs API or Node fs as the scaffold dictates; keep the path resolution (`~` expansion) in one helper.
+- Keep the public surface tiny: one reader function + the inferred type + the zod schema export (for reuse in tests).

--- a/.specify/briefings/M2.3.md
+++ b/.specify/briefings/M2.3.md
@@ -1,0 +1,52 @@
+# M2.3: `lib/github.ts` — Octokit wrapper + ETag polling + gh-auth shell-out
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 2.
+
+> **Dependency:** `external:M2.1`. Do not dispatch until the M2.1 scaffold is merged to `main`.
+
+## Goal
+
+Provide the dashboard's GitHub read path: an Octokit wrapper with ETag-aware conditional polling and on-demand auth borrowed from `gh auth token`. Pure data-access — no UI, no status derivation (that's M3.2). M2.4 consumes this for the portfolio view.
+
+## Hard constraints (security-critical — see [`architecture.md`](../../specs/projects/kerrigan-dashboard/architecture.md))
+
+- **Zero credential persistence (AC-017).** Never write a token, OAuth secret, or cookie to disk. Resolve auth fresh on each call via `gh auth token` shell-out. The token lives only in memory for the duration of a request.
+- **Never log/leak the token.** Do not log the token, write it to a file, or pass it to any non-GitHub process. Treat the `gh auth token` output as a secret.
+- **Restricted egress.** All HTTP targets `https://api.github.com` (and `https://*.githubusercontent.com` where needed). No other origins. This pairs with the CSP/`http.scope` allowlist M2.1 set — do not widen it.
+- **ETag cache short-circuits 304s.** Cache ETags per endpoint; send `If-None-Match`; treat 304 as "unchanged" (return cached data, no re-parse).
+- **Adaptive backoff (AC-014).** Default poll cadence 60s. On rate-limit pressure (low `X-RateLimit-Remaining` / 403 secondary-limit), back off; surface an "offline / unreachable" signal rather than throwing so the UI can show the offline indicator.
+- **Strict TS** under the M2.1 `tsconfig`.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/lib/github.ts` — new
+- `apps/kerrigan-dashboard/src/lib/github.test.ts` — new (Vitest, with a mocked Octokit / fetch — no live network)
+- `apps/kerrigan-dashboard/package.json` — add `@octokit/*` (rest/core) only
+
+## Read-only
+
+- `apps/kerrigan-dashboard/**` (existing scaffold)
+- `apps/kerrigan-dashboard/src/lib/projects.ts` (M2.2 output, if merged — consume its types; do not edit)
+- `specs/projects/kerrigan-dashboard/architecture.md`
+- Everything else
+
+## What "done" looks like
+
+1. A client factory that obtains a token via `gh auth token` shell-out and constructs an authenticated Octokit instance per call/session, holding the token only in memory.
+2. Read helpers for the data the portfolio needs (e.g. open PRs/issues for a repo) with ETag conditional requests; 304 returns cached results.
+3. Rate-limit/unreachable conditions return a typed "offline" result (no uncaught throw), enabling AC-014's offline indicator.
+4. Vitest covers: token shell-out is invoked (mocked), 200→data, 304→cached, rate-limit→offline result, and **a test asserting the token is never persisted/logged**.
+5. No real network in tests; no real `gh` invocation (mock the shell-out).
+6. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes.
+
+## Out of scope
+
+- Status taxonomy / derivation (M3.2 owns `lib/status.ts`).
+- Writes (issues/PRs) — read path only for now; the sidecar (M5) owns writes.
+- The portfolio UI (M2.4).
+- The CI secret-leak scan job (M2.5 owns `dashboard-build.yml` gitleaks + log-scan).
+
+## Notes
+
+- Shell out to `gh auth token` via the Tauri shell API restricted to that exact command (M2.1's capabilities allowlist). Do not invoke arbitrary shell.
+- Keep the public surface small: a `createGitHubClient()` + a couple of typed read helpers + the offline/result types.

--- a/.specify/briefings/M2.5.md
+++ b/.specify/briefings/M2.5.md
@@ -1,0 +1,49 @@
+# M2.5: `dashboard-build.yml` CI workflow + extend smoke scripts
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 2.
+
+> **Dependency:** `external:M2.1`. Do not dispatch until the M2.1 scaffold is merged to `main` — the workflow builds the app shell.
+
+## Goal
+
+Stand up the dashboard's build CI: a cross-platform (Windows / macOS / Linux) workflow that builds the Tauri app and asserts an artifact, plus the security scans the architecture requires, and extend the repo smoke scripts to cover the dashboard build.
+
+## Hard constraints
+
+- **New workflow only:** `.github/workflows/dashboard-build.yml`. Do not modify `verify.yml` or other existing workflows.
+- **Path-scoped trigger.** Run on PRs/pushes that touch `apps/kerrigan-dashboard/**` (and the workflow itself). Don't make every repo PR pay for a Tauri build.
+- **Matrix:** `windows-latest`, `macos-latest`, `ubuntu-latest`. Install pnpm + the platform's Tauri system deps; run `pnpm install`, lint, `pnpm -C apps/kerrigan-dashboard test`, and `pnpm -C apps/kerrigan-dashboard tauri build`; assert the installer/bundle artifact exists per platform.
+- **Security scans (from [`architecture.md`](../../specs/projects/kerrigan-dashboard/architecture.md)).** Add `gitleaks` and a custom check that fails the build if `gh auth token` output is ever logged, written to a file, or passed to a non-allowlisted process. Add the renderer-egress test: a non-allowlisted origin fetch must fail (CSP/`http.scope` enforcement).
+- **Keep it reasonably fast.** Cache pnpm store + Cargo registry/target where it helps; aim well under the repo's CI-time norms.
+
+## Files in scope (Touch)
+
+- `.github/workflows/dashboard-build.yml` — new
+- `scripts/smoke.sh` and `scripts/smoke.ps1` — extend to optionally build/launch the dashboard (guard so the existing repo-health smoke still runs where the app isn't present/needed)
+- `.github/test-mapping.yml` — map the new workflow/checks to the AC(s) they cover if the repo convention requires it
+
+## Read-only
+
+- `apps/kerrigan-dashboard/**` (build it; don't modify app source)
+- `specs/projects/kerrigan-dashboard/architecture.md`, `runbook.md`
+- `.github/workflows/verify.yml` (reference for style/conventions; do not edit)
+
+## What "done" looks like
+
+1. `dashboard-build.yml` runs the 3-OS matrix on dashboard-touching PRs and produces a build artifact on each OS.
+2. `gitleaks` + the token-leak custom check run and pass on a clean tree (and would fail on a planted leak).
+3. The renderer-egress test asserts a non-allowlisted origin fetch fails.
+4. `scripts/smoke.sh` / `scripts/smoke.ps1` extended without breaking their current repo-health behavior (existing smoke still green on a checkout without the app built).
+5. The new workflow is green on a PR that only touches the dashboard.
+6. `kerrigan check` passes; existing `verify.yml` checks unaffected.
+
+## Out of scope
+
+- Code signing / notarization / auto-updater (M7 owns).
+- Release/publish pipelines.
+- App business logic or tests beyond wiring the existing ones into CI.
+
+## Notes
+
+- Tauri system deps differ per OS (Linux needs `libwebkit2gtk`, etc.) — use the documented Tauri 2 CI setup for each runner.
+- Don't add the dashboard build as a *required* status check on `main` yet — land the workflow first, prove it green, then the conductor decides on protection (mirrors how `verify.yml` checks became required).

--- a/.specify/briefings/predictor-touch-format.md
+++ b/.specify/briefings/predictor-touch-format.md
@@ -1,0 +1,82 @@
+# conflict-predictor: parse the real `- Touch:` tasks.md format + fail-loud on zero parses
+
+Harness fix. Single-dispatch.
+
+## Problem
+
+`tools/conflict_predictor.py` only recognizes touch annotations written as
+`<!-- touch: glob1, glob2 -->` HTML comments. **No real `tasks.md` in this repo
+uses that format** — they use Markdown bullets:
+
+```
+- [ ] Task M2.3: lib/github.ts ...
+    - external:M2.1
+  - Touch: `apps/kerrigan-dashboard/src/lib/github.ts`, sibling test
+```
+
+A survey of all 15 `tasks.md` files: 0 use the HTML-comment form; the only one
+with annotations (`specs/projects/kerrigan-dashboard/tasks.md`) has 23 `- Touch:`
+bullets. So when the predictor runs on a real artifact it parses **0 tasks** and
+emits `waves: []` — a silent false "all clear" that would let a conductor
+parallel-dispatch conflicting tasks. This is a correctness bug, not cosmetic.
+
+## Goal
+
+Make the predictor work on the `tasks.md` format this repo actually uses, and
+make it impossible to silently greenlight a file it couldn't understand.
+
+## Hard constraints
+
+- **Parse the `- Touch:` bullet format.** A task is introduced by a checkbox line
+  (`- [ ] Task <ID>: ...`). Its touch globs may appear on a following indented
+  bullet `  - Touch: \`glob\`, \`glob\`` (note: globs may be wrapped in backticks;
+  strip them). A task may have **multiple** `Touch:` bullets (see M2.5 in the
+  dashboard tasks.md) — union them. Also support the legacy
+  `<!-- touch: ... -->` form so existing fixtures/tests keep working.
+- **Honor the real task-ID shape.** IDs in this repo look like `M2.3` / `Task M2.3`,
+  not only `T-001`. Don't force `T-NNN`; preserve the ID as written (trim a leading
+  `Task ` label). Keep `normalize_task_id` working for the `T-NNN` inputs the
+  existing tests use.
+- **Fail loud on zero-signal input (the key safety fix).** If `tasks.md` is
+  non-empty and contains task checkbox lines but **no** touch annotations are
+  found on any of them, do NOT write `waves: []` and exit 0. Instead exit non-zero
+  with a clear stderr message naming the file and the expected annotation forms.
+  An empty/whitespace tasks.md (no task lines at all) may still be a clean 0-wave
+  success.
+- **Don't change the output schema.** Keep `waves:\n  - wave: N\n    tasks: [...]`.
+
+## Files in scope (Touch)
+
+- `tools/conflict_predictor.py`
+- `tests/test_conflict_predictor.py`
+
+## Read-only
+
+- `specs/projects/kerrigan-dashboard/tasks.md` (use as the realistic parse fixture)
+- Everything else
+
+## What "done" looks like
+
+1. Running `python tools/conflict_predictor.py --tasks specs/projects/kerrigan-dashboard/tasks.md`
+   parses the M2.x tasks and produces non-empty, overlap-correct waves (tasks whose
+   touch globs overlap land in separate waves; disjoint ones share a wave).
+2. A non-empty tasks.md with task lines but no touch annotations → non-zero exit +
+   actionable stderr message (covered by a test).
+3. Multiple `Touch:` bullets on one task are unioned (covered by a test).
+4. Backtick-wrapped globs are stripped before matching (covered by a test).
+5. All existing `tests/test_conflict_predictor.py` cases still pass (HTML-comment
+   form + `T-NNN` IDs remain supported).
+6. `python -m pytest tests/test_conflict_predictor.py -q` green. `kerrigan check` passes.
+
+## Out of scope
+
+- Rewriting tasks.md files to a new format.
+- Dependency/`external:` ordering between tasks (waves are file-overlap only; the
+  conductor layers dependency ordering on top).
+- Any change to dispatch tooling or briefing generation.
+
+## Notes
+
+- The realistic fixture (dashboard tasks.md) is the acceptance bar — if it parses
+  and waves correctly, the fix is real. Keep the parser tolerant: ignore lines that
+  aren't tasks or touch bullets rather than throwing.

--- a/.specify/waves.yaml
+++ b/.specify/waves.yaml
@@ -1,0 +1,20 @@
+# Hand-authored: tools/conflict_predictor.py can't parse this repo's `- Touch:`
+# tasks.md format (it only reads `<!-- touch: -->` HTML comments) and silently
+# emits `waves: []`. Wave assignment below is derived from the briefing packets,
+# which are authoritative for files-actually-touched. See the predictor-fix task.
+#
+# Overlap analysis (kerrigan-dashboard Milestone 2):
+#   M2.2 (lib/projects.ts)  -> also mutates package.json + pnpm-lock.yaml (adds zod)
+#   M2.3 (lib/github.ts)    -> also mutates package.json + pnpm-lock.yaml (adds @octokit/*)
+#   M2.5 (dashboard-build.yml + smoke scripts) -> .github/ + scripts/ only (no package.json)
+#   M2.4 (portfolio view)   -> external:M2.2 + external:M2.3 (must follow both)
+#
+# => M2.2 and M2.3 collide on package.json/pnpm-lock.yaml, so they are serialized.
+#    M2.5 is disjoint and runs alongside M2.3 in wave 1.
+waves:
+  - wave: 1
+    tasks: [M2.3, M2.5]
+  - wave: 2
+    tasks: [M2.2]
+  - wave: 3
+    tasks: [M2.4]


### PR DESCRIPTION
Provenance for wave-2 dispatch. Adds briefing packets for M2.2/M2.3/M2.5 (kerrigan-dashboard Milestone 2) and a hand-authored .specify/waves.yaml.

Also adds a briefing for a harness fix: the conflict-predictor only parses `<!-- touch: -->` HTML comments, but all real tasks.md use `- Touch:` bullets, so it silently emits `waves: []`. Wave plan here is derived from the briefings (authoritative for files-touched), not the tool.

No code changes — docs/artifacts only.