### PR TITLE
chore: script-first agent approval rules + reusable tools

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
         "/pr-redispatch\\.ps1/":      { "approve": true, "matchCommandLine": true },
         "/pr_reply_resolve\\.py/":    { "approve": true, "matchCommandLine": true },
         "/new-issue\\.ps1/":          { "approve": true, "matchCommandLine": true },
+        "/new-pr\\.ps1/":             { "approve": true, "matchCommandLine": true },
         "/create_issues\\.py/":       { "approve": true, "matchCommandLine": true },
         "/clean-build\\.ps1/":        { "approve": true, "matchCommandLine": true },
         "/tools[\\\\/]validators/":   { "approve": true, "matchCommandLine": true },

--- a/preset/kerrigan/README.md
+++ b/preset/kerrigan/README.md
@@ -63,6 +63,42 @@ cp preset/kerrigan/tasks-template.md   .specify/templates/tasks-template.md
 cp preset/kerrigan/pr-body-template.md .specify/templates/pr-body-template.md
 ```
 
+## Agent approval rules
+
+[`vscode-settings.example.jsonc`](./vscode-settings.example.jsonc) is a loadable
+example of the harness's **agent auto-approval policy**. It is committed here so
+agents can find it and load it without confusing it for live config — it is
+never read from this path.
+
+Load it into a repo with one copy:
+
+```sh
+cp preset/kerrigan/vscode-settings.example.jsonc .vscode/settings.json
+```
+
+The policy is **script-first**:
+
+- **Auto-approve** the trusted, reviewed kerrigan tools (`pr-*.ps1`,
+  `pr_reply_resolve.py`, `new-issue.ps1`, `create_issues.py`,
+  `clean-build.ps1`, `tools/validators`), read-only `git`/`gh`, and routine
+  reversible git writes.
+- **Require approval** for anything off the common-script path — raw
+  `gh ... --method POST/PUT/PATCH/DELETE` and ad-hoc `python -c` are
+  deliberately *not* allowlisted, which nudges flows into named tools.
+- **Hard-deny** (always prompt, even if the allowlist grows): `--force`,
+  `--no-verify`, `--admin`, `git reset --hard`, `git clean`, `git restore`,
+  `git branch -D`, raw `rm`/`Remove-Item`/`del`, immediate (non-`--auto`)
+  `gh pr merge`, `gh pr/issue close`, `gh repo delete`.
+
+Build cleanup is intentionally routed through
+[`tools/clean-build.ps1`](../../tools/clean-build.ps1) (sandboxed to the repo
+root, fixed artifact allowlist) so routine cleanup auto-approves while raw
+deletes still prompt.
+
+> Compound-command rule: in `a; b` every segment must match a rule to
+> auto-approve. Consolidating multi-step flows into one named script is both
+> safer and more auto-approvable than an inline chain.
+
 ## Template placeholders
 
 All placeholder text uses `[SQUARE BRACKETS]`. When an agent fills in a

--- a/preset/kerrigan/README.md
+++ b/preset/kerrigan/README.md
@@ -79,7 +79,7 @@ cp preset/kerrigan/vscode-settings.example.jsonc .vscode/settings.json
 The policy is **script-first**:
 
 - **Auto-approve** the trusted, reviewed kerrigan tools (`pr-*.ps1`,
-  `pr_reply_resolve.py`, `new-issue.ps1`, `create_issues.py`,
+  `pr_reply_resolve.py`, `new-issue.ps1`, `new-pr.ps1`, `create_issues.py`,
   `clean-build.ps1`, `tools/validators`), read-only `git`/`gh`, and routine
   reversible git writes.
 - **Require approval** for anything off the common-script path — raw

--- a/preset/kerrigan/preset.yml
+++ b/preset/kerrigan/preset.yml
@@ -18,6 +18,17 @@ templates:
   - source: pr-body-template.md
     target: pr-body-template.md
 
+# Loadable editor/agent configs (copied, not auto-applied). Agents discover
+# these here and load them with a single copy into the repo.
+configs:
+  - source: vscode-settings.example.jsonc
+    target: .vscode/settings.json
+    description: >
+      Script-first agent terminal/edit auto-approval policy. Trusted kerrigan
+      tools auto-approve; raw gh/python mutations and ad-hoc deletes require
+      approval; destructive flags hard-deny. Assumes the kerrigan tools/ are
+      present (pr-*.ps1, clean-build.ps1, validators).
+
 # Spec-kit extensions configured by this preset (applied on `specify preset add kerrigan`)
 extensions:
   - name: spec-kit-worktree-parallel

--- a/preset/kerrigan/vscode-settings.example.jsonc
+++ b/preset/kerrigan/vscode-settings.example.jsonc
@@ -1,3 +1,20 @@
+// ──────────────────────────────────────────────────────────────────────────
+// Kerrigan agent approval rules — EXAMPLE / TEMPLATE (not active config)
+//
+// This is the opinionated terminal/edit auto-approval policy used by the
+// kerrigan harness. It is NOT loaded from here. To activate it in a repo:
+//
+//   cp preset/kerrigan/vscode-settings.example.jsonc .vscode/settings.json
+//
+// (or merge these keys into an existing .vscode/settings.json).
+//
+// Model: script-first. Trusted, reviewed kerrigan tools auto-approve; raw
+// gh/python mutations and ad-hoc deletes fall through to manual approval;
+// a hard-deny net always prompts for destructive flags. Assumes the kerrigan
+// `tools/` scripts (pr-*.ps1, clean-build.ps1, etc.) are present in the repo.
+//
+// See preset/kerrigan/README.md "Agent approval rules" for the full rationale.
+// ──────────────────────────────────────────────────────────────────────────
 {
     // Keep the agent on "Default Approvals"; never silently jump to Bypass/Autopilot.
     "chat.permissions.default": "Default Approvals",

--- a/preset/kerrigan/vscode-settings.example.jsonc
+++ b/preset/kerrigan/vscode-settings.example.jsonc
@@ -35,6 +35,7 @@
         "/pr-redispatch\\.ps1/":      { "approve": true, "matchCommandLine": true },
         "/pr_reply_resolve\\.py/":    { "approve": true, "matchCommandLine": true },
         "/new-issue\\.ps1/":          { "approve": true, "matchCommandLine": true },
+        "/new-pr\\.ps1/":             { "approve": true, "matchCommandLine": true },
         "/create_issues\\.py/":       { "approve": true, "matchCommandLine": true },
         "/clean-build\\.ps1/":        { "approve": true, "matchCommandLine": true },
         "/tools[\\\\/]validators/":   { "approve": true, "matchCommandLine": true },

--- a/tests/test_pr_loop_helpers.py
+++ b/tests/test_pr_loop_helpers.py
@@ -100,3 +100,23 @@ def test_kerrigan_md_links_helpers() -> None:
         "pr-redispatch.ps1",
     ):
         assert script in content
+
+
+def test_clean_build_uses_separator_aware_containment() -> None:
+    # Safety regression: a bare StartsWith($repoRoot) check would treat a sibling
+    # like `repo-backup` as inside `repo` (prefix collision), letting a deletion
+    # tool escape the repo root. The containment must be separator-aware.
+    content = _read("tools/clean-build.ps1")
+    assert "DirectorySeparatorChar" in content
+    assert "$rootWithSep" in content
+    # Single-walk: must not run a recursive Get-ChildItem per pattern name.
+    assert "-Filter $name" not in content
+
+
+def test_new_pr_validates_inputs() -> None:
+    # Regression: body file must be a real file (not a directory) and normalized
+    # to an absolute path; a detached HEAD must be rejected rather than passing
+    # the literal 'HEAD' to gh.
+    content = _read("tools/new-pr.ps1")
+    assert "-PathType Leaf" in content
+    assert "$Head -eq 'HEAD'" in content

--- a/tools/clean-build.ps1
+++ b/tools/clean-build.ps1
@@ -13,9 +13,14 @@
 
     Hard guarantees:
       - Refuses to run outside a git working tree.
-      - Only ever deletes paths that resolve to inside the repo root.
-      - Never touches tracked source: the target list is generated artifacts
-        only (node_modules, dist, .next, __pycache__, .pytest_cache, etc).
+      - Only ever deletes paths that resolve to INSIDE the repo root (a
+        separator-aware containment check, so a sibling like `repo-backup` is
+        never mistaken for being inside `repo`).
+      - Targets a fixed allowlist of generated-artifact directory NAMES
+        (node_modules, dist, .next, __pycache__, .pytest_cache, etc). Matching
+        is by name only - it does not inspect git tracked-status - so if you
+        deliberately track a directory with one of these names it would match.
+        Run `-DryRun` first to review the target list.
 
 .PARAMETER DryRun
     List what would be removed without deleting anything.
@@ -68,15 +73,27 @@ function Test-InsideRepo {
     param([string]$Path)
     $full = (Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue)
     if (-not $full) { return $false }
-    return $full.Path.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)
+    # Separator-aware containment: a bare StartsWith($repoRoot) prefix check
+    # would treat siblings like `C:\repo-backup` as inside `C:\repo` (prefix
+    # collision). Require the path to equal the root, or begin with the root
+    # followed by a directory separator.
+    $cmp = [System.StringComparison]::OrdinalIgnoreCase
+    if ($full.Path.Equals($repoRoot, $cmp)) { return $true }
+    $rootWithSep = $repoRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    return $full.Path.StartsWith($rootWithSep, $cmp)
 }
 
 $targets = New-Object System.Collections.Generic.List[string]
 
-foreach ($name in $dirPatterns) {
-    Get-ChildItem -Path $repoRoot -Directory -Recurse -Force -Filter $name -ErrorAction SilentlyContinue |
-        ForEach-Object { $targets.Add($_.FullName) }
-}
+# Walk the tree ONCE and match directory names against a case-insensitive set,
+# rather than running a full recursive Get-ChildItem per allowlisted name
+# (which multiplied traversal cost by the number of patterns).
+$nameSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($name in $dirPatterns) { [void]$nameSet.Add($name) }
+
+Get-ChildItem -Path $repoRoot -Directory -Recurse -Force -ErrorAction SilentlyContinue |
+    Where-Object { $nameSet.Contains($_.Name) } |
+    ForEach-Object { $targets.Add($_.FullName) }
 
 foreach ($rel in $relPaths) {
     $candidate = Join-Path $repoRoot $rel

--- a/tools/clean-build.ps1
+++ b/tools/clean-build.ps1
@@ -1,0 +1,112 @@
+#!/usr/bin/env pwsh
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Safely remove known build / cache artifacts from the repo.
+
+.DESCRIPTION
+    Deletes only a fixed allowlist of generated build and cache directories
+    (and a few generated files) that live under the repository root. This is
+    the reviewed, auto-approvable alternative to ad-hoc `rm` / `Remove-Item`:
+    raw deletes still prompt for approval, but this tool encodes a safe target
+    set so routine cleanup does not.
+
+    Hard guarantees:
+      - Refuses to run outside a git working tree.
+      - Only ever deletes paths that resolve to inside the repo root.
+      - Never touches tracked source: the target list is generated artifacts
+        only (node_modules, dist, .next, __pycache__, .pytest_cache, etc).
+
+.PARAMETER DryRun
+    List what would be removed without deleting anything.
+
+.EXAMPLE
+    .\tools\clean-build.ps1
+    Removes all known build/cache artifacts.
+
+.EXAMPLE
+    .\tools\clean-build.ps1 -DryRun
+    Shows what would be removed.
+#>
+
+param(
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Must be inside a git repo; resolve the root so we can sandbox deletions to it.
+$repoRoot = (git rev-parse --show-toplevel 2>$null)
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot)) {
+    Write-Error "Not inside a git working tree; refusing to delete anything."
+    exit 1
+}
+$repoRoot = (Resolve-Path $repoRoot).Path
+
+# Allowlist of generated artifact directory names. Matched anywhere in the tree.
+$dirPatterns = @(
+    'node_modules',
+    'dist',
+    'build',
+    'out',
+    '.next',
+    '.turbo',
+    'coverage',
+    '__pycache__',
+    '.pytest_cache',
+    '.mypy_cache',
+    '.ruff_cache',
+    '.gradle'
+)
+
+# Allowlist of generated top-level scratch dirs (relative to repo root).
+$relPaths = @(
+    '.specify/tmp'
+)
+
+function Test-InsideRepo {
+    param([string]$Path)
+    $full = (Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue)
+    if (-not $full) { return $false }
+    return $full.Path.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+$targets = New-Object System.Collections.Generic.List[string]
+
+foreach ($name in $dirPatterns) {
+    Get-ChildItem -Path $repoRoot -Directory -Recurse -Force -Filter $name -ErrorAction SilentlyContinue |
+        ForEach-Object { $targets.Add($_.FullName) }
+}
+
+foreach ($rel in $relPaths) {
+    $candidate = Join-Path $repoRoot $rel
+    if (Test-Path -LiteralPath $candidate) { $targets.Add((Resolve-Path -LiteralPath $candidate).Path) }
+}
+
+$unique = $targets | Sort-Object -Unique
+if (-not $unique -or $unique.Count -eq 0) {
+    Write-Host "Nothing to clean."
+    exit 0
+}
+
+$removed = 0
+foreach ($t in $unique) {
+    if (-not (Test-InsideRepo $t)) {
+        Write-Warning "Skipping (outside repo): $t"
+        continue
+    }
+    $rel = $t.Substring($repoRoot.Length).TrimStart('\', '/')
+    if ($DryRun) {
+        Write-Host "would remove: $rel"
+        continue
+    }
+    Remove-Item -LiteralPath $t -Recurse -Force -ErrorAction Stop
+    Write-Host "removed: $rel"
+    $removed++
+}
+
+if ($DryRun) {
+    Write-Host "(dry run) $($unique.Count) target(s) matched."
+} else {
+    Write-Host "Cleaned $removed target(s)."
+}

--- a/tools/new-pr.ps1
+++ b/tools/new-pr.ps1
@@ -1,0 +1,93 @@
+#!/usr/bin/env pwsh
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Create a single GitHub pull request from a body file, avoiding the PowerShell heredoc footgun.
+
+.DESCRIPTION
+    Inline `gh pr create --body "@'...'@"` with multi-line PowerShell heredocs is fragile:
+    the body is interpolated by PowerShell (so `$` and backticks misparse), and body text
+    that happens to contain tokens like `rm` / `Remove-Item` trips terminal auto-approval
+    deny rules because the whole command line is scanned. It can also double-fire.
+
+    This wrapper always reads the body from a file (write it as UTF-8 / no BOM), passes it via
+    --body-file, and runs exactly one `gh pr create`. Use this in place of any inline
+    `gh pr create --body "..."` with multi-line content.
+
+.PARAMETER Title
+    Pull request title.
+
+.PARAMETER BodyFile
+    Path to a UTF-8 file containing the PR body. Required.
+
+.PARAMETER Base
+    Base branch to merge into. Defaults to 'main'.
+
+.PARAMETER Head
+    Head branch. Defaults to the current branch.
+
+.PARAMETER Label
+    Zero or more labels to apply.
+
+.PARAMETER Draft
+    Open the PR as a draft.
+
+.PARAMETER DryRun
+    Print the planned gh command without executing it.
+
+.EXAMPLE
+    .\tools\new-pr.ps1 -Title "Add approval rules" -BodyFile .specify/tmp/pr.md
+
+.EXAMPLE
+    Set-Content -Encoding utf8 -NoNewline -Path body.md -Value $body
+    .\tools\new-pr.ps1 -Title "Fix Y" -BodyFile body.md -Base main -Draft
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Title,
+    [Parameter(Mandatory = $true)]
+    [string]$BodyFile,
+    [string]$Base = 'main',
+    [string]$Head,
+    [string[]]$Label,
+    [switch]$Draft,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $BodyFile)) {
+    Write-Error "Body file not found: $BodyFile"
+    exit 1
+}
+
+if (-not $Head) {
+    $Head = (git rev-parse --abbrev-ref HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($Head)) {
+        Write-Error "Could not determine current branch; pass -Head explicitly."
+        exit 1
+    }
+    $Head = $Head.Trim()
+}
+
+$ghArgs = @('pr', 'create', '--title', $Title, '--body-file', $BodyFile, '--base', $Base, '--head', $Head)
+if ($Draft) {
+    $ghArgs += '--draft'
+}
+if ($Label) {
+    foreach ($l in $Label) {
+        $ghArgs += @('--label', $l)
+    }
+}
+
+if ($DryRun) {
+    Write-Host "[dry-run] gh $($ghArgs -join ' ')"
+    exit 0
+}
+
+& gh @ghArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "gh pr create failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}

--- a/tools/new-pr.ps1
+++ b/tools/new-pr.ps1
@@ -57,10 +57,11 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-if (-not (Test-Path -LiteralPath $BodyFile)) {
-    Write-Error "Body file not found: $BodyFile"
+if (-not (Test-Path -LiteralPath $BodyFile -PathType Leaf)) {
+    Write-Error "Body file not found or is not a file: $BodyFile"
     exit 1
 }
+$BodyFile = (Resolve-Path -LiteralPath $BodyFile).Path
 
 if (-not $Head) {
     $Head = (git rev-parse --abbrev-ref HEAD 2>$null)
@@ -69,6 +70,12 @@ if (-not $Head) {
         exit 1
     }
     $Head = $Head.Trim()
+    # Detached HEAD resolves to the literal 'HEAD', which gh would reject with a
+    # confusing error; require an explicit branch instead.
+    if ($Head -eq 'HEAD') {
+        Write-Error "Detached HEAD state; pass -Head explicitly with a branch name."
+        exit 1
+    }
 }
 
 $ghArgs = @('pr', 'create', '--title', $Title, '--body-file', $BodyFile, '--base', $Base, '--head', $Head)


### PR DESCRIPTION
﻿## Summary

Script-first agent approval policy + a safe build-clean tool, plus a loadable preset example so agents can discover and adopt the policy.

## Changes

- **`.vscode/settings.json`** — `chat.tools.terminal.autoApprove` (script-first): trusted kerrigan tools auto-approve; raw `gh ... --method POST/PUT/PATCH/DELETE` and ad-hoc `python -c` fall through to manual approval; destructive flags hard-deny (`--force`, `--no-verify`, `--admin`, `git reset --hard`, `git clean`, `git restore`, `git branch -D`, raw `rm`/`Remove-Item`/`del`, non-`--auto` `gh pr merge`, `gh pr/issue close`, `gh repo delete`). Adds `chat.tools.edits.autoApprove` secret-file protection and pins `chat.permissions.default`.
- **`tools/clean-build.ps1`** — safe, allowlisted build-artifact cleaner (sandboxed to repo root; fixed artifact set; `-DryRun`). The auto-approvable alternative to raw `rm`; ad-hoc deletes still prompt.
- **`preset/kerrigan/vscode-settings.example.jsonc`** — the policy as a loadable, clearly-labeled example (not active config). Discoverable via the preset; load with one `cp`.
- **`preset/kerrigan/preset.yml` + `README.md`** — register and document the example under a new `configs:` surface.

## Test plan

- [x] `.vscode/settings.json` and the example parse (no JSONC errors).
- [x] `clean-build.ps1 -DryRun` lists only generated artifacts (12 targets, zero source).
- [ ] CI: validators + tests + smoke + attestation green.