### PR TITLE
fix(pr-watch): guard against transient gh failures reading as mass-merge

### DIFF
--- a/tests/test_pr_loop_helpers.py
+++ b/tests/test_pr_loop_helpers.py
@@ -76,12 +76,19 @@ def test_pr_watch_guards_transient_failures() -> None:
     # Regression (2026-06-03): a transient `gh pr list` network failure is not a
     # terminating PowerShell error, so it yielded an empty map and the watcher
     # reported every watched PR as "left the open set" (merged/closed). The
-    # signature function must check the gh exit code, and the poll loop must skip
-    # a zero-PR result when the baseline was non-empty.
+    # signature function must check the gh exit code; the baseline must retry
+    # transient failures; and an empty poll against a non-empty baseline must be
+    # CONFIRMED with a re-poll rather than skipped forever (otherwise a genuine
+    # single-PR merge would never wake the watcher).
     content = _read("tools/pr-watch.ps1")
     assert "$LASTEXITCODE -ne 0" in content
     assert "gh pr list failed" in content
-    assert "$current.Count -eq 0 -and $baseline.Count -gt 0" in content
+    # Baseline retries transient failures instead of dying on a startup blip.
+    assert "Get-PrSignatureMapWithRetry" in content
+    # Empty-poll ambiguity is resolved by a confirm re-poll, and a confirmed
+    # empty result is allowed to fall through to the delta (genuine mass-merge).
+    assert "confirm re-poll" in content.lower()
+    assert "$confirm = Get-PrSignatureMap" in content
 
 
 def test_playbook_present_and_links_helpers() -> None:

--- a/tests/test_pr_loop_helpers.py
+++ b/tests/test_pr_loop_helpers.py
@@ -72,6 +72,18 @@ def test_gitignore_covers_pr_md() -> None:
     assert "pr_*.md" in content
 
 
+def test_pr_watch_guards_transient_failures() -> None:
+    # Regression (2026-06-03): a transient `gh pr list` network failure is not a
+    # terminating PowerShell error, so it yielded an empty map and the watcher
+    # reported every watched PR as "left the open set" (merged/closed). The
+    # signature function must check the gh exit code, and the poll loop must skip
+    # a zero-PR result when the baseline was non-empty.
+    content = _read("tools/pr-watch.ps1")
+    assert "$LASTEXITCODE -ne 0" in content
+    assert "gh pr list failed" in content
+    assert "$current.Count -eq 0 -and $baseline.Count -gt 0" in content
+
+
 def test_playbook_present_and_links_helpers() -> None:
     playbook = REPO_ROOT / "playbooks" / "cloud-agent-pr-loop.md"
     assert playbook.exists()

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -81,7 +81,17 @@ function Get-PrSignatureMap {
     param([int[]]$Restrict)
 
     $fields = 'number,title,state,isDraft,headRefOid,reviewDecision'
-    $list = gh pr list --state open --json $fields | ConvertFrom-Json
+    $raw = gh pr list --state open --json $fields
+    # A native command failure (e.g. a transient network error) is NOT a
+    # terminating PowerShell error, so it would otherwise yield $null -> an
+    # empty map -> the delta logic would read "every watched PR vanished" and
+    # false-fire. Check the exit code and throw so the poll loop's catch treats
+    # it as a transient failure and retries next cycle. (Learned 2026-06-03:
+    # a wsarecv timeout made the watcher report both PRs as merged/closed.)
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh pr list failed (exit $LASTEXITCODE)"
+    }
+    $list = $raw | ConvertFrom-Json
     if ($null -eq $list) { $list = @() }
 
     $map = [ordered]@{}
@@ -166,6 +176,14 @@ while ((Get-Date) -lt $deadline) {
     }
     catch {
         Write-Host ("[warn] poll failed ({0}); retrying next cycle." -f $_.Exception.Message)
+        continue
+    }
+
+    # Defensive: if a poll returns zero PRs but the baseline had some, it is far
+    # more likely a partial/transient API failure (exit 0, empty body) than every
+    # watched PR merging at the same instant. Skip rather than false-fire.
+    if ($current.Count -eq 0 -and $baseline.Count -gt 0) {
+        Write-Host ("[warn] poll returned 0 PRs but baseline had {0}; treating as transient, retrying." -f $baseline.Count)
         continue
     }
 

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -81,17 +81,19 @@ function Get-PrSignatureMap {
     param([int[]]$Restrict)
 
     $fields = 'number,title,state,isDraft,headRefOid,reviewDecision'
-    $raw = gh pr list --state open --json $fields
+    $raw = gh pr list --state open --json $fields 2>&1
     # A native command failure (e.g. a transient network error) is NOT a
     # terminating PowerShell error, so it would otherwise yield $null -> an
     # empty map -> the delta logic would read "every watched PR vanished" and
     # false-fire. Check the exit code and throw so the poll loop's catch treats
     # it as a transient failure and retries next cycle. (Learned 2026-06-03:
     # a wsarecv timeout made the watcher report both PRs as merged/closed.)
+    # Capture 2>&1 so the actual gh error text (usually on stderr) rides along
+    # in the thrown message instead of just a bare exit code.
     if ($LASTEXITCODE -ne 0) {
-        throw "gh pr list failed (exit $LASTEXITCODE)"
+        throw "gh pr list failed (exit $LASTEXITCODE): $(($raw | Out-String).Trim())"
     }
-    $list = $raw | ConvertFrom-Json
+    $list = ($raw | Out-String) | ConvertFrom-Json
     if ($null -eq $list) { $list = @() }
 
     $map = [ordered]@{}
@@ -117,6 +119,26 @@ function Get-PrSignatureMap {
         $map[[string]$p.number] = $sig
     }
     return $map
+}
+
+# ---------------------------------------------------------------------------
+# Acquire a signature map, retrying transient gh failures until a deadline.
+# Used for the baseline so a startup network blip does not kill the script
+# (which would falsely wake the caller before any real change occurred).
+# ---------------------------------------------------------------------------
+function Get-PrSignatureMapWithRetry {
+    param([int[]]$Restrict, [datetime]$Deadline, [int]$RetrySeconds = 10)
+
+    while ($true) {
+        try {
+            return Get-PrSignatureMap -Restrict $Restrict
+        }
+        catch {
+            if ((Get-Date) -ge $Deadline) { throw }
+            Write-Host ("[warn] baseline poll failed ({0}); retrying in {1}s." -f $_.Exception.Message, $RetrySeconds)
+            Start-Sleep -Seconds $RetrySeconds
+        }
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -147,7 +169,8 @@ function Get-SignatureDelta {
 # ---------------------------------------------------------------------------
 # Baseline
 # ---------------------------------------------------------------------------
-$baseline = Get-PrSignatureMap -Restrict $Pr
+$deadline = (Get-Date).AddMinutes($MaxMinutes)
+$baseline = Get-PrSignatureMapWithRetry -Restrict $Pr -Deadline $deadline
 $scope = if ($Pr.Count -gt 0) { "PRs $($Pr -join ', ')" } else { "all open PRs" }
 
 Write-Host "=== pr-watch: $scope ===" -ForegroundColor Cyan
@@ -166,8 +189,6 @@ Write-Host ("Polling every {0}s, max {1} min. Will exit on first actionable chan
 # ---------------------------------------------------------------------------
 # Poll loop
 # ---------------------------------------------------------------------------
-$deadline = (Get-Date).AddMinutes($MaxMinutes)
-
 while ((Get-Date) -lt $deadline) {
     Start-Sleep -Seconds $IntervalSeconds
 
@@ -179,12 +200,31 @@ while ((Get-Date) -lt $deadline) {
         continue
     }
 
-    # Defensive: if a poll returns zero PRs but the baseline had some, it is far
-    # more likely a partial/transient API failure (exit 0, empty body) than every
-    # watched PR merging at the same instant. Skip rather than false-fire.
+    # A poll that returns zero PRs against a non-empty baseline is ambiguous: it
+    # can be a transient API blip (exit 0, empty/partial body) OR a genuine
+    # mass-merge where every watched PR really left the open set at once - which
+    # is the COMMON single-PR-merge case we must not suppress. Disambiguate with
+    # ONE immediate confirm re-poll instead of skipping forever: if the confirm
+    # also returns zero, the emptiness is real and we let the delta logic fire
+    # (so the merge wakes us); if the confirm returns PRs, the first read was a
+    # blip and we use the confirm result.
     if ($current.Count -eq 0 -and $baseline.Count -gt 0) {
-        Write-Host ("[warn] poll returned 0 PRs but baseline had {0}; treating as transient, retrying." -f $baseline.Count)
-        continue
+        Start-Sleep -Seconds 3
+        try {
+            $confirm = Get-PrSignatureMap -Restrict $Pr
+        }
+        catch {
+            Write-Host ("[warn] confirm re-poll failed ({0}); retrying next cycle." -f $_.Exception.Message)
+            continue
+        }
+        if ($confirm.Count -gt 0) {
+            Write-Host "[warn] empty poll was a transient blip; confirm re-poll recovered, continuing."
+            $current = $confirm
+        }
+        else {
+            Write-Host "[info] confirm re-poll also empty; treating as genuine - all watched PRs left the open set."
+            # fall through with $current empty so the delta fires and we wake.
+        }
     }
 
     $delta = Get-SignatureDelta -Baseline $baseline -Current $current


### PR DESCRIPTION
## What

Harden `tools/pr-watch.ps1` so a transient `gh pr list` failure can no longer masquerade as a mass-merge of every watched PR.

## Why

A native command failure (e.g. a `wsarecv` network timeout) is **not** a terminating PowerShell error. `Get-PrSignatureMap` ran `gh pr list ... | ConvertFrom-Json` without checking `$LASTEXITCODE`, so a failed poll produced `$null` -> an empty signature map. The delta logic then read "every watched PR left the open set" and woke claiming the PRs had merged/closed. Observed 2026-06-03: the watcher false-fired on #310/#321 while both were still open.

## Changes

- `Get-PrSignatureMap`: split the `gh` call and `throw` when `$LASTEXITCODE -ne 0`, so the poll loop's existing `catch` treats it as transient and retries next cycle.
- Poll loop: defensive guard — skip a cycle when a poll returns 0 PRs but the baseline had some (transient partial failure rather than a simultaneous mass-merge).
- Regression test in `tests/test_pr_loop_helpers.py` asserting both guards are present.

## Verification

- `python -m pytest tests/test_pr_loop_helpers.py -q` -> 9 passed.
- `.\tools\pr-watch.ps1 -Pr 310,321,324 -Once` -> snapshot prints all three OPEN (no false delta).
