### PR TITLE
fix(dispatch): assign @copilot directly in new-issue.ps1 (drop GraphQL fallback)

### DIFF
--- a/.specify/briefings/M2.4.md
+++ b/.specify/briefings/M2.4.md
@@ -1,0 +1,74 @@
+# M2.4: Portfolio view + project card component
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 2.
+
+> **Dependencies:** `external:M2.2` (`lib/projects.ts`) and `external:M2.3` (`lib/github.ts`) — both merged to `main`. Consume them **as-is**; do not edit either file.
+
+## Goal
+
+Render route `/` as the portfolio card grid: one card per project from `~/.kerrigan/projects.json`, each showing the six fields required by **AC-002** — project name, repo count, current wave, block count, intervention count, last-PR-merged timestamp. Wire real data through `lib/projects.ts` (M2.2) + `lib/github.ts` (M2.3). Show an offline indicator (AC-014) when GitHub is unreachable. This is the first real view; the app shell exists in `App.tsx` and currently renders a placeholder.
+
+## Hard constraints
+
+- **Consume M2.2 + M2.3, do not modify them.** Import `readProjects` / `Project` / `RepoRef` from [`src/lib/projects.ts`](../../apps/kerrigan-dashboard/src/lib/projects.ts) and `createGitHubClient` / `GitHubClient` / `GitHubResult` / `PullRequestData` / `IssueData` from [`src/lib/github.ts`](../../apps/kerrigan-dashboard/src/lib/github.ts). If you find you *need* a new GitHub helper (see "last-PR-merged" below), **do not add it to `github.ts`** — use a documented fallback and note the follow-up. Editing `github.ts`/`projects.ts` is out of scope (other slices own them).
+- **Never persist or log a GitHub token.** You only call `github.ts`'s typed helpers; you never touch `gh auth token` directly. Don't log raw API responses that could contain sensitive fields.
+- **Offline-tolerant (AC-014).** Every `GitHubResult` is a discriminated union — handle `{ ok: false, offline: true, reason }` by rendering cached/empty state plus a visible `offline — last synced HH:MM` indicator. Never let an unreachable API crash the view or throw.
+- **Graceful degradation, never overcount.** When a data source is unavailable (no working copy on disk, GitHub offline), render a neutral placeholder (`—` for unknown wave/timestamp, `0` for counts) rather than failing. Counts must never exceed what the available sources prove.
+- **Strict TS** under the existing `tsconfig`. No `any`. Derive types from the imported libs.
+- **Design tokens only.** Use the Tailwind tokens already defined in [`tailwind.config.ts`](../../apps/kerrigan-dashboard/tailwind.config.ts) (`neutral-bg #0D1117`, `neutral-fg #E8EAED`, `brand #5965F2`, `accent #F59E0B`, the `display/heading/body/micro/nano` font sizes, the custom spacing scale). Per [`design-references.md`](../../specs/projects/kerrigan-dashboard/design-references.md): card-per-project grid, glanceable status; **amber (`accent`) for intervention/blocked counts** (needs-attention), red reserved for true blocks.
+
+## Card field → data source (exact rules)
+
+| Field | Source | Fallback |
+|---|---|---|
+| **name** | `project.name` | — (always present) |
+| **repo count** | `project.repos.length` | — |
+| **current wave** | Active wave from `<workingCopyPath>/.specify/waves.yaml` in the project's first available working copy | `—` when no working copy / file absent |
+| **block count** | Number of `<workingCopyPath>/.specify/blocks/*.yaml` files | `0` |
+| **intervention count** | Subset of the AC-012 inbox definition computable now: **open blocks** (the block count above) **+** open issues across the project's repos labeled both `agent:wait` **and** `capture` (via `github.ts` `listIssues`) | `0` (and document that attestation requests + unresolved-critical-review-thread sources are added when `lib/inbox.ts` lands — AC-012/M-later) |
+| **last-PR-merged timestamp** | **Gap:** `github.ts` (M2.3) exposes `listOpenPRs` only — no merged-PR helper. Render `—`. **Do not** add a merged-PR helper to `github.ts` in this slice. | `—` (see "Plan adjustments") |
+
+Implement the field aggregation behind an **injectable data layer** so the card component stays pure and the composition is unit-testable without a real filesystem or network:
+
+- New file `src/lib/portfolio.ts`: a `buildPortfolioCards(...)` (or `usePortfolioData`-style) function that takes the project list + a `GitHubClient` + an injectable working-copy reader (`(workingCopyPath) => Promise<{ wave: string | null; blockCount: number }>`), and returns a typed `PortfolioCardData[]` view-model plus a top-level offline flag + `lastSyncedAt`. The default working-copy reader uses the Tauri fs API (restricted to the M2.1 capability allowlist — read-only, scoped to declared `workingCopyPaths`); tests inject a fake.
+- `components/ProjectCard` is a **pure** component: it receives one `PortfolioCardData` and renders — no data fetching inside.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/routes/portfolio/**` — new (the view + its hook/loader; wire into `App.tsx`)
+- `apps/kerrigan-dashboard/src/components/ProjectCard/**` — new (pure card + its component test)
+- `apps/kerrigan-dashboard/src/lib/portfolio.ts` + `src/lib/portfolio.test.ts` — new (aggregation/composition + unit tests)
+- `apps/kerrigan-dashboard/src/App.tsx` — replace the placeholder `<main>` with the portfolio route
+- `apps/kerrigan-dashboard/package.json` — add only what's needed: `@testing-library/react` + `@testing-library/jest-dom` (Vitest component tests) and `@playwright/test` (E2E). No router library required for M2 (single `/` view); defer routing to M3.3.
+- `apps/kerrigan-dashboard/playwright.config.ts` + `apps/kerrigan-dashboard/e2e/portfolio.spec.ts` + fixtures — new
+- `apps/kerrigan-dashboard/vitest` setup file if needed for `@testing-library` matchers
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/projects.ts`, `src/lib/github.ts` (consume; never edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,acceptance-tests.md,architecture.md,design-references.md}`
+- The M1 pre-vis `specs/projects/kerrigan-dashboard/previs/index.html` (visual reference for card layout/tokens)
+- Everything else
+
+## What "done" looks like
+
+1. `pnpm -C apps/kerrigan-dashboard dev:web` (or the built preview) renders route `/` as a card grid; with a 3-project fixture, three cards appear, each showing all six AC-002 fields (placeholders where a source is unavailable per the table above).
+2. GitHub unreachable → cards still render from cached/empty state **and** a visible `offline — last synced HH:MM` indicator appears; no crash (AC-014).
+3. Cards match the pre-vis design tokens (colors, type scale, spacing); intervention/blocked counts use the amber `accent`.
+4. **Vitest component tests** for `ProjectCard` (renders each field; placeholder states; amber styling on non-zero intervention) and **`lib/portfolio.test.ts`** unit tests for the aggregation (wave/block/intervention rules, offline path, graceful degradation — all with injected fakes, no real fs/network).
+5. **Playwright E2E `e2e/portfolio.spec.ts`** against the Vite **web build** (`vite preview`) with a fixture `projects.json` and intercepted GitHub network:
+   - `renders-all-projects` — three cards with the six fields.
+   - `offline-indicator` — with GitHub network failed/aborted, the offline indicator is visible and the app does not crash.
+6. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes. The smoke script still passes.
+
+## Out of scope / plan adjustments (call these out in the PR description)
+
+- **`last-PR-merged` timestamp** renders `—` this slice because M2.3's `github.ts` has no merged-PR read path. Follow-up: a separate slice extends `github.ts` with a merged-PR helper (search or `pulls?state=closed`), then this field wires up. Do **not** widen `github.ts` here.
+- **`intervention count`** is the *currently computable subset* of the AC-012 inbox (blocks + `agent:wait`+`capture` issues). Attestation requests and unresolved-critical-review-thread inputs arrive with `lib/inbox.ts` (later milestone). Documented, not silently dropped.
+- **Cold-start `<1s` from Tauri process start (AC-001)** and the **post-shutdown `~/.kerrigan/` token-scan (AC-018 M2.4 portion)** require the built **Tauri binary** + CI harness, which **M2.5** (`dashboard-build.yml` + extended smoke) owns. This slice delivers the web-build first-paint E2E and the in-memory no-token-persistence guarantee (inherited from M2.3); the Tauri-shell cold-start timing + filesystem token-scan are validated under M2.5. Note this hand-off in the PR; if you believe AC-001's Tauri timing must land here, emit a block rather than scope-creeping.
+- Project-detail navigation (M3.3), DAG, chat, inbox view, writes/dispatch — all later milestones.
+
+## Notes
+
+- No router for M2 — `App.tsx` renders the portfolio directly. Keep the seam clean so M3.3 can introduce routing without rewriting the view.
+- If any boundary above is wrong (e.g. a needed source genuinely can't degrade gracefully, or AC-001 must be satisfied here), write `.specify/blocks/M2.4.yaml` with the reason + recommendation and stop — don't expand scope silently.

--- a/.specify/briefings/M3.1.md
+++ b/.specify/briefings/M3.1.md
@@ -1,0 +1,63 @@
+# M3.1: Plan markdown parser (`lib/plan-parser.ts`)
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 3.
+
+> **Dependencies:** none. This is a pure, self-contained module — it can land in parallel with the in-flight M2 finish (#327). No file overlap with any open PR.
+
+## Goal
+
+Parse a project `plan.md` into a typed stage graph that downstream milestones (M3.2 status derivation, M3.3 DAG canvas, M7 PR-flow overlay) consume. Resolves **OQ-001** in [`spec.md`](../../specs/projects/kerrigan-dashboard/spec.md). The module is pure (string in, typed graph out) — **no filesystem, no network, no React**.
+
+## Behavior
+
+- Extract **stages from `H2` / `H3` headings**. The heading text is the stage label; derive a stable `id` (slugified heading, deduped on collision). Nesting matters: an `H3` under an `H2` is a child stage — record the parent relationship.
+- Support **optional YAML frontmatter** declaring explicit stage dependencies:
+  ```yaml
+  ---
+  dependencies:
+    <stage-id>: [<stage-id>, ...]
+  ---
+  ```
+  (Accept the equivalent flat `dependencies: [stage-id, ...]` form named in tasks.md as a per-stage list too — document whichever shape you implement and keep it consistent. Frontmatter is optional; absence is not an error.)
+- Return a typed graph: `{ nodes: StageNode[]; edges: StageEdge[] }` where a node carries `{ id, label, level (2|3), parentId: string | null, lineStart, lineEnd }` and an edge carries `{ from, to, kind: 'dependency' | 'hierarchy' }`.
+- **Handle malformed input gracefully with structured errors** — never throw. Return a discriminated result (`{ ok: true, graph }` | `{ ok: false, errors: ParseError[] }`) following the same house pattern as [`lib/projects.ts`](../../apps/kerrigan-dashboard/src/lib/projects.ts) (`ProjectsResult`). A `ParseError` carries `{ message, line?, kind }`.
+- **Detect circular dependencies** in the declared dependency edges and surface them as a structured error (do not infinite-loop).
+
+## Hard constraints
+
+- **Pure module, no side effects.** No `fs`, no network, no Tauri APIs, no React imports. Input is the raw markdown string (+ optional options object).
+- **Strict TS** under the existing `tsconfig`. No `any`. Export the public types (`StageNode`, `StageEdge`, `StageGraph`, `ParseError`, the result union).
+- **Never throw on bad input.** Empty plan, no headings, malformed frontmatter, circular deps, duplicate headings → all return structured results, never exceptions.
+- **Match house conventions.** Mirror the `Result`-union + zod-validation style already used in `lib/projects.ts`. Use `zod` (already a dependency) to validate the frontmatter shape; pull `yaml` parsing from an existing dep if one is present, otherwise add a single well-known parser (`yaml`) to `package.json` and note it.
+- **Deterministic output.** Same input → same graph (stable id derivation + stable ordering).
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/lib/plan-parser.ts` — new (the parser + exported types)
+- `apps/kerrigan-dashboard/src/lib/plan-parser.test.ts` — new (Vitest)
+- `apps/kerrigan-dashboard/package.json` — only if a YAML parser must be added (`yaml`); nothing else
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/projects.ts` (style reference for the `Result` union + zod usage — do not edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,tasks.md}`
+- This project's own `specs/projects/kerrigan-dashboard/plan.md` makes a good real-world parse fixture
+- Everything else
+
+## What "done" looks like
+
+1. `lib/plan-parser.ts` exports a parse function returning the typed `StageGraph` result described above.
+2. **Vitest unit tests — 15+ cases**, including: simple H2-only plan; nested H2/H3 hierarchy; missing frontmatter (still ok); malformed frontmatter (structured error, no throw); explicit dependency edges parsed; **circular dependency detected** as a structured error; duplicate heading text (ids deduped); empty plan (ok with empty graph or structured error — pick and document); headings with markdown inline formatting in the text; a dependency referencing a non-existent stage id (structured error). Parsing this repo's own `plan.md` should succeed.
+3. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes. Smoke still passes.
+
+## Out of scope
+
+- Rendering the graph (React Flow / dagre) — that's **M3.3**.
+- Mapping stages to PR/issue status — that's **M3.2** (it consumes this module's `id`s).
+- Writing/editing plans — M6.
+- Reading the file from disk — the caller passes the string; do not add a loader here.
+
+## Notes
+
+- Keep the public type surface minimal and stable; M3.2/M3.3/M7 all key off `StageNode.id`, so design ids to be durable.
+- If a boundary here is wrong (e.g. the frontmatter dependency shape genuinely can't express what M3.2 needs), write `.specify/blocks/M3.1.yaml` with the reason + recommendation and stop — don't expand scope silently.

--- a/.specify/briefings/M4.1.md
+++ b/.specify/briefings/M4.1.md
@@ -1,0 +1,53 @@
+# M4.1: `lib/acp-client.ts` — ACP wrapper around `copilot --acp`
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 4.
+
+> **Dependencies:** `~external:M2.1` (app scaffold) — merged. This module can scaffold against the placeholder app; it touches **only** a new `lib/` file + its test. No file overlap with any open PR.
+
+## Goal
+
+Provide the TypeScript transport layer the chat pane (M4.2) will render on top of: a module that spawns `copilot --acp` as a subprocess, manages JSON-RPC framing over its stdio, and exposes a clean async API — `sendUserTurn(text) -> AsyncIterable<AcpEvent>`. This is the **wrapper only**; no UI. Implements the transport portion of **AC-010**.
+
+## Behavior
+
+- **Spawn + lifecycle.** Start `copilot --acp` as a child process (Tauri shell/command API on the app side; in tests the spawn is **injected** — see below). Initialize the ACP session per the protocol handshake, then keep the process alive for the session and **shut it down cleanly on app close / explicit `dispose()`** (no orphaned processes).
+- **JSON-RPC framing.** Implement the ACP message framing over stdin/stdout (Content-Length-delimited JSON-RPC, per ACP). Correlate requests/responses by id; route server-initiated notifications to the event stream.
+- **`sendUserTurn(text)`** returns an `AsyncIterable<AcpEvent>` that yields, in order, the streamed events for that turn and completes when the turn ends. Model `AcpEvent` as a discriminated union covering at minimum: `message_chunk` (streaming assistant text), `tool_call`, `tool_result`, `thought`, and a terminal `turn_end` (plus an `error` variant). M4.2 renders each variant — design the union so it maps cleanly to React components.
+- **Actionable error surfaces.** Detect and surface, as typed errors (not raw throws into the stream where avoidable): **`copilot` CLI missing** ("Copilot CLI not found — install …"), **CLI too old / `--acp` unsupported** ("Copilot CLI vX required for ACP — update with …"), subprocess crash, and malformed/again-unframeable output. Messages must tell the user what to do.
+
+## Hard constraints
+
+- **Injectable spawn for testability.** Do not hard-call the Tauri command API inside the core. Take a `spawn`-like dependency (`(cmd, args) => AcpProcess` where `AcpProcess` exposes `stdin`/`stdout` streams + `kill()`), so tests drive a **mocked ACP server** with zero real subprocess. The default factory wires the Tauri shell API; tests inject a fake.
+- **Never persist or log credentials.** `copilot --acp` handles its own auth; this module must not read, store, or log tokens. Do not echo raw subprocess stderr that could leak secrets — surface sanitized, typed errors.
+- **Clean shutdown, no leaks.** `dispose()` (and app-close) terminates the child and rejects/closes any in-flight turn iterators. No dangling listeners, no zombie processes.
+- **Strict TS.** No `any`. Export `AcpEvent` (the full union), the client interface, the error types, and the injectable `spawn` type.
+- **Pure transport, no React.** No component imports here; this is `lib/` only.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/lib/acp-client.ts` — new (the client + types + default Tauri-backed spawn factory)
+- `apps/kerrigan-dashboard/src/lib/acp-client.test.ts` — new (Vitest against a mocked ACP server)
+- `apps/kerrigan-dashboard/package.json` — only if a minimal JSON-RPC/stream helper is genuinely needed; prefer hand-rolled framing with no new dep. If you add the Tauri shell plugin capability, keep it scoped per the M2.1 capability allowlist and note it.
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/projects.ts` / `github.ts` (house style for `Result` unions + injectable dependencies — do not edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,architecture.md,tasks.md}`
+- Everything else
+
+## What "done" looks like
+
+1. `lib/acp-client.ts` exposes a client whose `sendUserTurn(text)` returns an `AsyncIterable<AcpEvent>` and whose `dispose()` shuts the subprocess down.
+2. **Vitest unit tests against a mocked ACP server** covering: full session lifecycle (init → turn → end); **every `AcpEvent` variant** emitted in order from a scripted server; multi-chunk streaming assembled correctly; **CLI-missing** and **CLI-too-old** error paths surface the actionable typed errors; subprocess crash mid-turn rejects/closes the iterator; `dispose()` kills the process and ends in-flight iterators. No real subprocess is spawned in tests.
+3. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes. Smoke still passes.
+
+## Out of scope
+
+- The chat pane UI / event renderers — **M4.2** (consumes this module's `AcpEvent` union).
+- The Kerrigan MCP server + `kerrigan.dispatch` and sidecar wiring — **M5** (`--additional-mcp-config` plumbing lands there).
+- Persisting conversation history.
+
+## Notes
+
+- The `AcpEvent` union is the contract M4.2 builds on — make the variants explicit and exhaustive so the renderer can `switch` without a default-any.
+- If the ACP framing/protocol details can't be pinned down from the CLI's documented behavior (e.g. event shapes differ from the assumptions above), write `.specify/blocks/M4.1.yaml` with the specific uncertainty + recommendation and stop — don't guess the wire format silently.

--- a/.specify/briefings/M8.1.md
+++ b/.specify/briefings/M8.1.md
@@ -1,0 +1,57 @@
+# M8.1: Cross-project inbox aggregator (`lib/inbox.ts`)
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 8.
+
+> **Dependencies:** `external:M2.3` (`lib/github.ts`) — merged to `main`. Consume it **as-is**; do not edit it. Also consumes `lib/projects.ts` (M2.2, merged). No file overlap with any open PR.
+
+## Goal
+
+Aggregate everything that needs human attention across **all** projects in `~/.kerrigan/projects.json` into one typed, age-sorted feed. This is the data layer for the M8.2 inbox view and the source the M2.4 portfolio "intervention count" eventually widens to. Implements **AC-012** (the aggregation portion). Pure data module — **no React, no direct UI**.
+
+## Behavior
+
+Produce a unified `InboxItem[]` feed drawn from these sources, for every project + repo in the project list:
+
+1. **Open blocks** — `<workingCopyPath>/.specify/blocks/*.yaml` across the project's working copies (each unresolved block → one item).
+2. **`agent:wait` + `capture` issues** — open issues labeled **both** `agent:wait` **and** `capture` (the mobile-capture inbox), via `github.ts` `listIssues`.
+3. **PRs with unresolved review threads** — open PRs that have outstanding reviewer feedback. **Gap:** M2.3's `github.ts` exposes `getPRReviews` (REST review states) but **no review-thread-resolution read path** (that's a GraphQL `reviewThreads` concept). Use the **computable proxy** available from `getPRReviews` — PRs whose latest review state is `CHANGES_REQUESTED` (or `COMMENTED` with no subsequent approval) — and **document** that precise unresolved-thread detection arrives when `github.ts` gains a GraphQL thread helper (follow-up slice). **Do not** widen `github.ts` here.
+4. **Attestation requests** — **Gap:** there is no attestation source helper in M2.3 yet. Model the `InboxItem` `kind: 'attestation'` in the union so the feed shape is complete, but leave the source as an injectable hook that returns empty by default, and **document** that it wires up when the attestation read path lands. Don't invent a source.
+
+Return a **typed unified feed sorted by age** (oldest-first, i.e. most-overdue first). Each `InboxItem` carries at minimum `{ id, kind: 'block' | 'capture-issue' | 'review' | 'attestation', projectId, repo?: RepoRef, title, url?, createdAt, ageMs }`.
+
+## Hard constraints
+
+- **Consume M2.2 + M2.3, do not modify them.** Import `readProjects` / `Project` / `RepoRef` from [`lib/projects.ts`](../../apps/kerrigan-dashboard/src/lib/projects.ts) and `createGitHubClient` / `GitHubClient` / `GitHubResult` / `IssueData` / `PullRequestData` from [`lib/github.ts`](../../apps/kerrigan-dashboard/src/lib/github.ts). Need a new GitHub helper? **Do not add it to `github.ts`** — use a documented proxy/fallback and note the follow-up.
+- **Injectable sources for testability.** The block-file reader (`(workingCopyPath) => Promise<BlockSummary[]>`) and the attestation source are **injected**; the default block reader uses the Tauri fs API (read-only, scoped to declared `workingCopyPaths` per the M2.1 capability allowlist). Tests inject fakes — **no real fs/network in unit tests**.
+- **Offline-tolerant (AC-014).** Every `github.ts` call returns a `GitHubResult` discriminated union — handle `{ ok: false, offline: true, reason }` by contributing whatever sources are available (e.g. local blocks still surface) plus a feed-level offline flag + `lastSyncedAt`. Never throw on an unreachable API.
+- **Never overcount, never crash.** A missing working copy, an offline repo, or a project with no repos degrades to fewer items — never an exception, never a fabricated item. Counts/items must never exceed what the available sources prove.
+- **Never persist or log a GitHub token.** Only call `github.ts`'s typed helpers; never touch `gh auth token` directly; don't log raw API responses with sensitive fields.
+- **Strict TS.** No `any`. Export `InboxItem`, the `kind` union, and the feed result type (with the offline flag + `lastSyncedAt`), following the house `Result`-union style.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/lib/inbox.ts` — new (the aggregator + exported types + default injectable source factories)
+- `apps/kerrigan-dashboard/src/lib/inbox.test.ts` — new (Vitest with fixture GitHub responses + injected fakes)
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/projects.ts`, `src/lib/github.ts` (consume; never edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,acceptance-tests.md,tasks.md}` (AC-012 definition)
+- Everything else
+
+## What "done" looks like
+
+1. `lib/inbox.ts` exports a `buildInbox(...)` (or similar) that takes the project list + a `GitHubClient` + the injectable block/attestation sources and returns the typed, age-sorted feed + offline flag + `lastSyncedAt`.
+2. **Vitest unit tests — 12+ cases** with fixture GitHub responses + injected source fakes: blocks-only feed; capture-issue-only feed; review-proxy items (CHANGES_REQUESTED surfaces, an approved PR does not); multi-project + multi-repo aggregation; **age sort** (oldest first); **offline path** (GitHub down → local blocks still surface + offline flag set, no throw); missing working copy degrades gracefully; empty project list → empty feed; the `attestation` kind is representable but defaults empty. No real fs/network.
+3. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes. Smoke still passes.
+
+## Out of scope / plan adjustments (call these out in the PR description)
+
+- **Unresolved-review-thread precision** uses the `getPRReviews` proxy this slice; exact GraphQL `reviewThreads` detection is a follow-up after `github.ts` gains that read path. Do **not** widen `github.ts` here.
+- **Attestation source** is a modeled-but-empty injectable hook until the attestation read path lands. Documented, not silently dropped.
+- The inbox **view + per-item actions** (dispatch/close/snooze) — **M8.2**. The mobile-capture triage side panel — **M8.3**. This slice is the aggregator only.
+
+## Notes
+
+- Design `InboxItem` so M8.2 can filter by `projectId`, `kind`, and `ageMs` without re-deriving anything.
+- If a boundary is wrong (e.g. AC-012 genuinely requires real thread resolution to be useful and the proxy is misleading), write `.specify/blocks/M8.1.yaml` with the reason + recommendation and stop — don't expand scope silently.

--- a/tests/test_new_issue.py
+++ b/tests/test_new_issue.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Tests for the new-issue.ps1 dispatch helper."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_new_issue_has_help_sections() -> None:
+    content = _read("tools/new-issue.ps1")
+    for token in (".SYNOPSIS", ".DESCRIPTION", ".PARAMETER", ".EXAMPLE"):
+        assert token in content
+
+
+def test_new_issue_normalizes_copilot_assignee() -> None:
+    # The Copilot coding agent is a Bot actor: gh only accepts the '@copilot'
+    # handle for it. Bare 'copilot' fails with "'copilot' not found". The helper
+    # must normalize the known aliases to '@copilot' so `-Assignee copilot` works
+    # without any GraphQL fallback.
+    content = _read("tools/new-issue.ps1")
+    assert "'copilot', '@copilot', 'copilot-swe-agent'" in content
+    assert "$Assignee = '@copilot'" in content
+    assert "$Assignee.ToLowerInvariant()" in content
+
+
+def test_new_issue_uses_body_file_single_invocation() -> None:
+    # Guards the heredoc double-fire footgun: the body must come from --body-file
+    # and gh must be invoked exactly once via the splatted arg array.
+    content = _read("tools/new-issue.ps1")
+    assert "--body-file" in content
+    assert content.count("& gh @args") == 1

--- a/tools/new-issue.ps1
+++ b/tools/new-issue.ps1
@@ -23,7 +23,11 @@
     Zero or more labels to apply.
 
 .PARAMETER Assignee
-    Optional assignee handle (e.g. 'copilot' or a username).
+    Optional assignee handle. To assign the Copilot coding agent, pass any of
+    'copilot', 'Copilot', '@copilot', or 'copilot-swe-agent' — they are all
+    normalized to '@copilot', which is the handle gh requires for the bot actor
+    (bare 'copilot' fails with "'copilot' not found"). Any other value is passed
+    through to gh unchanged.
 
 .PARAMETER Milestone
     Optional milestone name.
@@ -32,6 +36,7 @@
     Print the planned gh command without executing it.
 
 .EXAMPLE
+    # Assign the Copilot coding agent (normalized to @copilot internally).
     .\tools\new-issue.ps1 -Title "Wire up X" -BodyFile .specify/briefings/x.md -Label agent:go -Assignee copilot
 
 .EXAMPLE
@@ -64,6 +69,13 @@ if ($Label) {
     }
 }
 if ($Assignee) {
+    # The Copilot coding agent is a Bot actor: gh only accepts the '@copilot'
+    # handle for it (bare 'copilot' / 'Copilot' / 'copilot-swe-agent' all fail
+    # with "'copilot' not found"). Normalize the known aliases to '@copilot'.
+    $copilotAliases = @('copilot', '@copilot', 'copilot-swe-agent')
+    if ($copilotAliases -contains $Assignee.ToLowerInvariant()) {
+        $Assignee = '@copilot'
+    }
     $args += @('--assignee', $Assignee)
 }
 if ($Milestone) {


### PR DESCRIPTION
﻿## What

	ools/new-issue.ps1 now normalizes the Copilot coding-agent aliases (copilot, @copilot, copilot-swe-agent) to the @copilot handle before calling gh issue create --assignee.

## Why

gh (verified 2.83.2) assigns the Copilot coding agent **only** via the `@copilot` handle. Bare `copilot` fails with `'copilot' not found` because the agent is a Bot actor. Previously dispatch fell back to a hand-rolled GraphQL `replaceActorsForAssignable` mutation per issue — unnecessary friction. With this fix, `-Assignee copilot` Just Works through `gh` directly; no GraphQL.

Verified: `gh issue edit N --add-assignee "@copilot"` -> exit 0; `"copilot"` -> exit 1 (`'copilot' not found`).

## Tests

- `tests/test_new_issue.py` asserts the normalization, the help sections, and the single-`gh`-invocation body-file guard.

## Also included

The `.specify/briefings/{M2.4,M3.1,M4.1,M8.1}.md` dispatch briefings created this session (traceability for issues #326/#328/#329/#330).