### PR TITLE
feat(pr-tools): pr-promote empty-PR gate + rerun, pr-watch -Mine

### DIFF
--- a/.github/agents/kerrigan.md
+++ b/.github/agents/kerrigan.md
@@ -175,7 +175,8 @@ Use these helper scripts during the PR dispatch/review/merge loop:
 - `tools/pr-resolve-threads.ps1 <pr-number>` — lists unresolved review threads and resolves them (supports `-DryRun`).
 - `tools/pr-rerun-pending.ps1 <pr-number>` — reruns workflow runs on the PR branch with `conclusion=action_required`.
 - `tools/pr-redispatch.ps1 <pr-number>` — posts a multi-line redispatch comment and re-arms auto-merge.
-- `tools/pr-promote.ps1 <pr-number>` — promotes draft PRs through ready/update-branch/reviewer/auto-merge in strict order.
+- `tools/pr-promote.ps1 <pr-number>` — runs the MANDATORY empty-PR pre-flight gate (refuses zero-file / `Initial plan`-only PRs, exit 2), then promotes through ready/update-branch/reviewer/auto-merge in strict order, then nudges `action_required` checks. One command per finished PR; don't hand-roll the `gh` sequence. (`-SkipPreflight` / `-SkipRerun` to opt out of either bookend.)
+- `tools/pr-watch.ps1 -Mine` — the wake bridge scoped to my + Copilot-authored open PRs, re-derived each poll cycle so new cloud PRs auto-join and merged ones drop. Prefer over passing explicit `-Pr` numbers and relaunching with a hand-maintained list.
 
 ### When Copilot finishes (signal: `[WIP]` removed from PR title — Copilot can't mark PRs ready itself)
 

--- a/.specify/briefings/M3.2.md
+++ b/.specify/briefings/M3.2.md
@@ -1,0 +1,78 @@
+# M3.2: Status taxonomy + derivation (`lib/status.ts`)
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 3.
+
+> **Dependencies (both merged to `main`):** `external:M3.1` (`lib/plan-parser.ts`) and `external:M2.3` (`lib/github.ts`). Consume both **as-is**; do not edit either. No file overlap with the in-flight M8.1 (`lib/inbox.ts`).
+
+## Goal
+
+Add `lib/status.ts`: map a plan stage's associated PRs / issues / blocks to exactly one of the **AC-005** statuses — `planned`, `dispatched`, `in-review`, `blocked`, `needs-attestation`, `needs-human-test`, `merged`. This is the taxonomy the M3.3 DAG canvas colors nodes by and the M7 PR-flow overlay keys lifecycle off. **Pure module** — no network, no filesystem, no React; it operates over data it is *handed*.
+
+## Consume these exact shapes (do not redefine)
+
+From [`lib/plan-parser.ts`](../../apps/kerrigan-dashboard/src/lib/plan-parser.ts):
+- `PlanStageNode { id: string; label: string; level: 2 | 3; parentId: string | null }`
+- `PlanStageGraph { nodes; edges }`, `PlanStageEdge { from; to; kind: "parent" | "dependency" }`
+- `parsePlanMarkdown(markdown): PlanParseResult` (returns `{ nodes, edges, errors }` — always, errors may be non-empty).
+
+From [`lib/github.ts`](../../apps/kerrigan-dashboard/src/lib/github.ts):
+- `PullRequestData { number; title; state; draft; user; created_at; updated_at; head{ref,sha}; base{ref}; html_url }`
+- `IssueData { number; title; state; user; created_at; updated_at; labels: ReadonlyArray<{ name?: string }>; html_url }`
+- `ReviewData { id; user; state; submitted_at; body; html_url }` (`state` ∈ `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / …)
+- `GitHubResult<T> = { ok: true; data: T } | { ok: false; offline: true; reason: string }`
+- `GitHubClient` exposes only `getRepo`, `listOpenPRs`, `listIssues`, `getPRReviews`.
+
+## Design (pure + table-driven + injectable linkage)
+
+1. **`export type StageStatus`** = the seven AC-005 values exactly. Read **spec.md AC-005** and [`acceptance-tests.md`](../../specs/projects/kerrigan-dashboard/acceptance-tests.md) for the canonical definition of each status and the **precedence order** when multiple signals apply (e.g. a stage that is both `in-review` and `blocked`). **Document the precedence in the module header comment** — do not invent it; derive it from the spec.
+2. **`deriveStageStatus(input): StageStatus`** — a **pure** function over a per-stage bundle: `{ prs: PullRequestData[]; issues: IssueData[]; blocks: BlockSummary[]; reviewsByPr?: Map<number, ReviewData[]> }`. Implement all seven branches as a documented decision table. Examples of the signal→status mapping (confirm exact rules against AC-005):
+   - open block(s) present → `blocked`
+   - `agent:needs-attestation` / `agent:needs-human-test` label (or the spec's named signal) → `needs-attestation` / `needs-human-test`
+   - an associated PR with a `CHANGES_REQUESTED`/pending-review thread (via `reviewsByPr`) → `in-review`
+   - an `agent:go`-assigned issue with an open PR but no review yet → `dispatched`
+   - a merged PR for the stage → `merged` (**see the merged-data gap below**)
+   - none of the above → `planned`
+3. **Stage→work linkage is injectable.** A stage links to issues/PRs by a convention (the task id — e.g. `M3.2` — appearing in the issue/PR title). Take a **matcher** `(stage: PlanStageNode, item: { title: string }) => boolean` with a sensible default, but keep `status.ts` agnostic so tests don't hard-depend on the naming scheme. Optionally export `deriveStatuses(graph, { prs, issues, blocks, reviewsByPr }, matcher?): Map<string, StageStatus>` that applies `deriveStageStatus` across the whole graph.
+4. **Multi-repo aggregation (AC-016).** A stage may match work across several repos; aggregate to the **highest-precedence** status across all matched items.
+
+## Hard constraints
+
+- **Consume M3.1 + M2.3, do not modify them.** Import the types above; never edit `plan-parser.ts` / `github.ts`.
+- **Pure, no side effects.** No `fs`/network/Tauri/React. The caller fetches via `GitHubClient` and reads blocks; `status.ts` only maps the handed data.
+- **Strict TS.** No `any`. Export `StageStatus`, `BlockSummary` (or reuse one if M8.1 lands a shared type — but do **not** create a dependency on the in-flight `inbox.ts`; define your own minimal `BlockSummary` here and let a later slice unify), and the derivation function(s).
+- **Total function.** Every input combination resolves to exactly one `StageStatus`; never throw. Empty input → `planned`.
+
+## Merged-data gap (call this out in the PR description)
+
+`github.ts` (M2.3) exposes **`listOpenPRs` only** and `PullRequestData` has **no `merged`/`merged_at` field** — there is no read path for merged PRs. So:
+- Implement the `merged` branch correctly over whatever PR data the function is **given** (tests inject a fixture PR representing a merged PR via `state` / an explicit flag in your input bundle).
+- **Do not widen `github.ts`** to add a merged-PR helper in this slice. Document that live `merged`-status detection wires up when a separate slice extends `github.ts` with a closed/merged-PR read path (same follow-up M2.4's `last-PR-merged` field waits on).
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/lib/status.ts` — new (taxonomy + derivation + module-header precedence doc)
+- `apps/kerrigan-dashboard/src/lib/status.test.ts` — new (Vitest, table-driven)
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/plan-parser.ts`, `src/lib/github.ts`, `src/lib/projects.ts` (consume; never edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,acceptance-tests.md}` (AC-005 statuses + precedence; AC-016 multi-repo)
+- Everything else
+
+## What "done" looks like
+
+1. `lib/status.ts` exports `StageStatus` (the seven AC-005 values), the pure `deriveStageStatus` (and optionally `deriveStatuses` over a graph), with the precedence documented in the module header.
+2. **Vitest table-driven tests** — at minimum **one case per AC-005 status** plus: precedence resolution when two signals apply; **multi-repo aggregation (AC-016)** picks the highest-precedence status; empty input → `planned`; the injectable matcher is exercised. No real fs/network — all fixtures.
+3. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes. Smoke still passes.
+
+## Out of scope
+
+- Rendering / node coloring — **M3.3** (consumes `StageStatus`).
+- The PR-flow particle lifecycle — **M7** (consumes `StageStatus` transitions).
+- Fetching the data / wiring a real `GitHubClient` into a route — a later integration slice; this module stays pure.
+- Extending `github.ts` with a merged-PR path — separate follow-up.
+
+## Notes
+
+- `StageStatus` is the contract M3.3 + M7 build on — keep the seven values exact and stable.
+- If a boundary is wrong (e.g. AC-005 genuinely needs a signal that none of `github.ts`'s helpers can provide and degrading is misleading), write `.specify/blocks/M3.2.yaml` with the reason + recommendation and stop — don't expand scope silently.

--- a/tests/test_pr_loop_helpers.py
+++ b/tests/test_pr_loop_helpers.py
@@ -91,6 +91,17 @@ def test_pr_watch_guards_transient_failures() -> None:
     assert "$confirm = Get-PrSignatureMap" in content
 
 
+def test_pr_watch_mine_mode_derives_author_set() -> None:
+    # -Mine scopes the watch to my + Copilot-authored PRs, re-derived each poll
+    # so new cloud PRs auto-join and merged ones drop without relaunching.
+    content = _read("tools/pr-watch.ps1")
+    assert "[switch]$Mine" in content
+    assert "gh api user --jq" in content
+    assert "'Copilot'" in content
+    # The author filter is threaded through the per-cycle signature map.
+    assert "-OnlyAuthors" in content
+
+
 def test_playbook_present_and_links_helpers() -> None:
     playbook = REPO_ROOT / "playbooks" / "cloud-agent-pr-loop.md"
     assert playbook.exists()

--- a/tests/test_pr_promote.py
+++ b/tests/test_pr_promote.py
@@ -26,6 +26,27 @@ def test_pr_promote_has_help_and_params() -> None:
     assert "[switch]$DryRun" in content
     assert "[string]$MergeMethod = 'squash'" in content
     assert "[switch]$SkipReviewer" in content
+    assert "[switch]$SkipPreflight" in content
+    assert "[switch]$SkipRerun" in content
+
+
+def test_pr_promote_preflight_gate_precedes_ready() -> None:
+    # The empty-PR gate must run BEFORE the PR is marked ready, and must refuse
+    # (exit 2) a PR with no files or only scaffold commits (the #294 class).
+    content = _read("tools/pr-promote.ps1")
+    assert "gh pr view $PrNumber --json files,commits" in content
+    assert "[BLOCK]" in content
+    assert "exit 2" in content
+    assert "Initial plan" in content
+    assert content.index("--json files,commits") < content.index("gh pr ready")
+
+
+def test_pr_promote_reruns_pending_checks_last() -> None:
+    # After arming auto-merge, nudge the action_required bot-branch workflows.
+    content = _read("tools/pr-promote.ps1")
+    assert "pr-rerun-pending.ps1" in content
+    # rindex: the help text mentions the script too; the actual invocation is last.
+    assert content.index("gh pr merge") < content.rindex("pr-rerun-pending.ps1")
 
 
 def test_pr_promote_invokes_four_steps_in_order() -> None:
@@ -79,6 +100,10 @@ def test_pr_promote_aborts_when_update_branch_fails(tmp_path: Path) -> None:
               echo "Kixantrix/kerrigan"
               exit 0
             fi
+            if [[ "$1" == "pr" && "$2" == "view" ]]; then
+              echo '{"files":[{"path":"a.ts"}],"commits":[{"messageHeadline":"Initial plan"},{"messageHeadline":"feat: real work"}]}'
+              exit 0
+            fi
             if [[ "$1" == "pr" && "$2" == "ready" ]]; then
               exit 0
             fi
@@ -116,6 +141,62 @@ def test_pr_promote_aborts_when_update_branch_fails(tmp_path: Path) -> None:
     assert "pr update-branch 123" in calls
     assert "requested_reviewers" not in calls
     assert "pr merge 123" not in calls
+
+
+def test_pr_promote_blocks_empty_pr(tmp_path: Path) -> None:
+    # Pre-flight gate: a PR with zero files / only an `Initial plan` commit must
+    # be refused (exit 2) before any promotion step touches it.
+    pwsh = shutil.which("pwsh")
+    if pwsh is None:
+        raise AssertionError("pwsh is required for this test")
+
+    call_log = tmp_path / "gh-calls.log"
+    gh = tmp_path / "gh"
+    gh.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            echo "$*" >> "$GH_CALL_LOG"
+            if [[ "$1" == "repo" && "$2" == "view" ]]; then
+              echo "Kixantrix/kerrigan"
+              exit 0
+            fi
+            if [[ "$1" == "pr" && "$2" == "view" ]]; then
+              echo '{"files":[],"commits":[{"messageHeadline":"Initial plan"}]}'
+              exit 0
+            fi
+            exit 0
+            """
+        ),
+        encoding="utf-8",
+    )
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+
+    env = os.environ.copy()
+    env["GH_CALL_LOG"] = str(call_log)
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    result = subprocess.run(
+        [pwsh, "-NoProfile", "-File", str(REPO_ROOT / "tools/pr-promote.ps1"), "123"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    calls = call_log.read_text(encoding="utf-8")
+    assert "pr view 123" in calls
+    assert "pr ready 123" not in calls
+    assert "pr merge 123" not in calls
+
+
+def test_pr_promote_skip_preflight_bypasses_gate() -> None:
+    content = _read("tools/pr-promote.ps1")
+    assert "$SkipPreflight" in content
+    # The gate is conditional on the switch, not unconditional.
+    assert "if ($SkipPreflight)" in content
 
 
 def test_playbook_lists_promote() -> None:

--- a/tools/pr-promote.ps1
+++ b/tools/pr-promote.ps1
@@ -2,14 +2,25 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-    Promote a draft PR into the merge queue sequence.
+    Promote a draft PR into the merge queue sequence, gated by a pre-flight
+    content check.
 
 .DESCRIPTION
-    Runs the four PR promotion steps in strict order:
+    Runs a MANDATORY pre-flight gate, then the four PR promotion steps in strict
+    order, then a rerun nudge:
+
+    0) Pre-flight gate (unless -SkipPreflight): inspect the PR's files + commits.
+       If the PR has zero changed files, or its only commits are scaffold/merge
+       commits (e.g. `Initial plan`), the cloud agent stalled and prematurely
+       cleared `[WIP]`. REFUSE to promote (exit 2) rather than auto-merging an
+       empty PR to main. (Guards the 2026-05-27 #294 empty-merge incident class.)
     1) Mark PR ready for review
     2) Update branch from main
     3) Request Copilot reviewer (unless skipped)
     4) Arm auto-merge with selected merge method
+    5) Rerun action_required checks (unless -SkipRerun): bot-authored branches
+       leave workflow runs in `action_required` after the synchronize push;
+       this nudges them via tools/pr-rerun-pending.ps1.
 
     Dry run mode prints commands without executing them.
 
@@ -24,6 +35,13 @@
 
 .PARAMETER SkipReviewer
     Skip requesting the Copilot reviewer.
+
+.PARAMETER SkipPreflight
+    Skip the pre-flight empty-PR gate. Use only when you have already verified
+    the PR has real content by other means.
+
+.PARAMETER SkipRerun
+    Skip the trailing pr-rerun-pending nudge.
 
 .EXAMPLE
     .\tools\pr-promote.ps1 282
@@ -40,7 +58,9 @@ param(
     [switch]$DryRun,
     [ValidateSet('squash', 'merge', 'rebase')]
     [string]$MergeMethod = 'squash',
-    [switch]$SkipReviewer
+    [switch]$SkipReviewer,
+    [switch]$SkipPreflight,
+    [switch]$SkipRerun
 )
 
 $ErrorActionPreference = 'Stop'
@@ -56,7 +76,19 @@ function Invoke-Step {
 
     try {
         $global:LASTEXITCODE = 0
-        & $Command
+        # gh writes its success confirmations to stderr; under the script-scope
+        # $ErrorActionPreference='Stop' a native stderr write is promoted to a
+        # terminating error, which previously made successful steps (e.g.
+        # marking the PR ready) report [FAIL] with the success text as the
+        # message. Lower EAP for just the native call and rely on the explicit
+        # $LASTEXITCODE check below to decide success/failure.
+        $previousEap = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            & $Command
+        } finally {
+            $ErrorActionPreference = $previousEap
+        }
         if ($LASTEXITCODE -ne 0) {
             throw ("Command exited with code {0}." -f $LASTEXITCODE)
         }
@@ -87,6 +119,36 @@ if ($DryRun) {
         exit 1
     }
     Write-Host "[OK] Resolved repository owner/name."
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight gate: refuse empty / scaffold-only PRs. A cloud agent that stalls
+# can clear [WIP] with nothing (or only an `Initial plan` commit) on the branch;
+# promoting that auto-merges an empty PR to main (the #294 incident class).
+# ---------------------------------------------------------------------------
+if ($SkipPreflight) {
+    Write-Host "[SKIP] Pre-flight empty-PR gate (requested by -SkipPreflight)."
+} elseif ($DryRun) {
+    Write-Host "[OK] [dry-run] gh pr view $PrNumber --json files,commits  (pre-flight empty-PR gate)"
+} else {
+    $preflightRaw = gh pr view $PrNumber --json files,commits 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host ("[FAIL] Pre-flight: gh pr view #{0}: {1}" -f $PrNumber, (($preflightRaw | Out-String).Trim()))
+        exit 1
+    }
+    $preflight = ($preflightRaw | Out-String) | ConvertFrom-Json
+    $fileCount = @($preflight.files).Count
+    $headlines = @($preflight.commits | ForEach-Object { ([string]$_.messageHeadline).Trim() } | Where-Object { $_ -ne '' })
+    # A commit is "substantive" if it is not a scaffold (`Initial plan`) or a
+    # merge commit. A PR with no substantive commit has nothing to merge.
+    $substantive = @($headlines | Where-Object { $_ -notmatch '^(Initial plan|Merge )' })
+    if ($fileCount -eq 0 -or $substantive.Count -eq 0) {
+        Write-Host ("[BLOCK] Pre-flight refused PR #{0}: files={1}, substantive commits={2}." -f $PrNumber, $fileCount, $substantive.Count) -ForegroundColor Red
+        Write-Host "        The cloud agent likely stalled and cleared [WIP] prematurely."
+        Write-Host "        Close the PR and reopen the issue, or re-dispatch. (Use -SkipPreflight to override.)"
+        exit 2
+    }
+    Write-Host ("[OK] Pre-flight: PR #{0} has {1} file(s) and {2} substantive commit(s)." -f $PrNumber, $fileCount, $substantive.Count)
 }
 
 if (-not (Invoke-Step -Label "Ready PR #$PrNumber" -ContinueOnFailure -Command {
@@ -138,6 +200,30 @@ if (-not (Invoke-Step -Label "Arm auto-merge ($MergeMethod) for PR #$PrNumber" -
     }
 })) {
     exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Rerun nudge: bot-authored branches leave required-check workflow runs in
+# `action_required` after the synchronize push from update-branch. Auto-merge
+# will never fire while they sit pending, so kick them. Best-effort: the merge
+# is already armed, so a rerun failure must not fail the promotion.
+# ---------------------------------------------------------------------------
+if ($SkipRerun) {
+    Write-Host "[SKIP] Rerun action_required checks (requested by -SkipRerun)."
+} elseif ($DryRun) {
+    Write-Host "[OK] [dry-run] tools/pr-rerun-pending.ps1 $PrNumber"
+} else {
+    $rerunScript = Join-Path $PSScriptRoot 'pr-rerun-pending.ps1'
+    if (Test-Path -LiteralPath $rerunScript) {
+        try {
+            & $rerunScript $PrNumber
+            Write-Host "[OK] Reran action_required checks."
+        } catch {
+            Write-Host ("[WARN] Rerun nudge failed (auto-merge still armed): {0}" -f $_.Exception.Message) -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "[WARN] pr-rerun-pending.ps1 not found; skipping rerun nudge."
+    }
 }
 
 exit 0

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -40,6 +40,13 @@
     One or more PR numbers to watch. If omitted, watches ALL currently-open PRs
     and also fires when a brand-new open PR appears.
 
+.PARAMETER Mine
+    Watch only the PRs that belong to this conductor's work: PRs authored by the
+    current gh user OR by the Copilot coding agent. The set is RE-DERIVED every
+    poll cycle, so a newly-opened cloud PR auto-joins the watch and a merged one
+    drops out -- no need to pass explicit numbers or relaunch with a new list.
+    Ignored if -Pr is given (an explicit list wins).
+
 .PARAMETER IntervalSeconds
     Seconds between poll cycles. Default 90.
 
@@ -58,11 +65,18 @@
 .EXAMPLE
     .\tools\pr-watch.ps1 -Pr 310,320
     Watch only #310 and #320; exit on the first actionable change to either.
+
+.EXAMPLE
+    .\tools\pr-watch.ps1 -Mine
+    Watch my own + Copilot-authored open PRs, re-derived each cycle, so new
+    cloud PRs auto-join and merged ones drop without relaunching with a new list.
 #>
 
 param(
     [Parameter(Position = 0)]
     [int[]]$Pr = @(),
+
+    [switch]$Mine,
 
     [int]$IntervalSeconds = 90,
 
@@ -78,9 +92,9 @@ $ErrorActionPreference = 'Stop'
 # One `gh pr list` call. When -Pr is given, restrict to that set.
 # ---------------------------------------------------------------------------
 function Get-PrSignatureMap {
-    param([int[]]$Restrict)
+    param([int[]]$Restrict, [string[]]$OnlyAuthors)
 
-    $fields = 'number,title,state,isDraft,headRefOid,reviewDecision'
+    $fields = 'number,title,state,isDraft,headRefOid,reviewDecision,author'
     $raw = gh pr list --state open --json $fields 2>&1
     # A native command failure (e.g. a transient network error) is NOT a
     # terminating PowerShell error, so it would otherwise yield $null -> an
@@ -99,6 +113,13 @@ function Get-PrSignatureMap {
     $map = [ordered]@{}
     foreach ($p in $list) {
         if ($Restrict.Count -gt 0 -and ($Restrict -notcontains $p.number)) { continue }
+        # -Mine restricts to PRs authored by the current user or the Copilot
+        # coding agent. The set is recomputed each cycle (this function runs per
+        # poll), so newly-opened cloud PRs join and merged ones drop on their own.
+        if ($OnlyAuthors.Count -gt 0) {
+            $login = if ($null -ne $p.author) { [string]$p.author.login } else { '' }
+            if ($OnlyAuthors -notcontains $login) { continue }
+        }
         $wip = if ($p.title -match '\[WIP\]') { 'wip' } else { 'ready' }
         $draft = if ($p.isDraft) { 'draft' } else { 'open' }
         # mergeStateStatus is deliberately EXCLUDED from the signature: it churns
@@ -127,11 +148,11 @@ function Get-PrSignatureMap {
 # (which would falsely wake the caller before any real change occurred).
 # ---------------------------------------------------------------------------
 function Get-PrSignatureMapWithRetry {
-    param([int[]]$Restrict, [datetime]$Deadline, [int]$RetrySeconds = 10)
+    param([int[]]$Restrict, [string[]]$OnlyAuthors, [datetime]$Deadline, [int]$RetrySeconds = 10)
 
     while ($true) {
         try {
-            return Get-PrSignatureMap -Restrict $Restrict
+            return Get-PrSignatureMap -Restrict $Restrict -OnlyAuthors $OnlyAuthors
         }
         catch {
             if ((Get-Date) -ge $Deadline) { throw }
@@ -167,11 +188,26 @@ function Get-SignatureDelta {
 }
 
 # ---------------------------------------------------------------------------
+# Resolve the -Mine author filter (current gh user + the Copilot coding agent).
+# Skipped when -Pr is given (an explicit list wins) or -Mine is not set.
+# ---------------------------------------------------------------------------
+$authorFilter = @()
+if ($Mine -and $Pr.Count -eq 0) {
+    $me = (gh api user --jq '.login' 2>&1)
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($me | Out-String))) {
+        Write-Host "[warn] -Mine: could not resolve current gh user; watching Copilot-authored PRs only."
+        $authorFilter = @('Copilot')
+    } else {
+        $authorFilter = @(($me | Out-String).Trim(), 'Copilot')
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Baseline
 # ---------------------------------------------------------------------------
 $deadline = (Get-Date).AddMinutes($MaxMinutes)
-$baseline = Get-PrSignatureMapWithRetry -Restrict $Pr -Deadline $deadline
-$scope = if ($Pr.Count -gt 0) { "PRs $($Pr -join ', ')" } else { "all open PRs" }
+$baseline = Get-PrSignatureMapWithRetry -Restrict $Pr -OnlyAuthors $authorFilter -Deadline $deadline
+$scope = if ($Pr.Count -gt 0) { "PRs $($Pr -join ', ')" } elseif ($authorFilter.Count -gt 0) { "my + Copilot open PRs ($($authorFilter -join ', '))" } else { "all open PRs" }
 
 Write-Host "=== pr-watch: $scope ===" -ForegroundColor Cyan
 Write-Host ("Baseline ({0} PR(s)) at {1}:" -f $baseline.Count, (Get-Date -Format 'HH:mm:ss'))
@@ -193,7 +229,7 @@ while ((Get-Date) -lt $deadline) {
     Start-Sleep -Seconds $IntervalSeconds
 
     try {
-        $current = Get-PrSignatureMap -Restrict $Pr
+        $current = Get-PrSignatureMap -Restrict $Pr -OnlyAuthors $authorFilter
     }
     catch {
         Write-Host ("[warn] poll failed ({0}); retrying next cycle." -f $_.Exception.Message)
@@ -211,7 +247,7 @@ while ((Get-Date) -lt $deadline) {
     if ($current.Count -eq 0 -and $baseline.Count -gt 0) {
         Start-Sleep -Seconds 3
         try {
-            $confirm = Get-PrSignatureMap -Restrict $Pr
+            $confirm = Get-PrSignatureMap -Restrict $Pr -OnlyAuthors $authorFilter
         }
         catch {
             Write-Host ("[warn] confirm re-poll failed ({0}); retrying next cycle." -f $_.Exception.Message)


### PR DESCRIPTION
﻿## What

- **pr-promote.ps1**: mandatory empty-PR pre-flight gate (refuses zero-file / Initial-plan-only PRs, exit 2 — the #294 empty-merge class), a trailing pr-rerun-pending nudge, and a fix for the [FAIL] Ready false-negative (lower EAP around native gh calls so stderr success lines don't throw).
- **pr-watch.ps1**: new -Mine mode derives the watch set from my + Copilot-authored open PRs each cycle, so new cloud PRs auto-join and merged ones drop without relaunching with a hand-maintained list.

## Why

This session I hand-rolled the promote sequence 4x, re-maintained watch lists by hand, and relied on memory for the pre-flight gate. This folds those into the tools so the safety is mechanical and the bookkeeping disappears.

## Tests

Static + functional (CI/pwsh): pre-flight precedes ready, refuses empty PRs (exit 2), reruns last, -Mine derives author set. Pre-flight decision logic validated locally across block/pass/scaffold cases.

## Also

M3.2 dispatch briefing + kerrigan.md helper docs updated.