### PR TITLE
fix(pr-watch): -Mine matches copilot bot login by regex (was silently excluding cloud PRs)

### DIFF
--- a/tests/test_pr_loop_helpers.py
+++ b/tests/test_pr_loop_helpers.py
@@ -100,6 +100,11 @@ def test_pr_watch_mine_mode_derives_author_set() -> None:
     assert "'Copilot'" in content
     # The author filter is threaded through the per-cycle signature map.
     assert "-OnlyAuthors" in content
+    # Regression (2026-06-08): the Copilot coding agent's author.login from
+    # `gh pr list --json author` is 'app/copilot-swe-agent', not 'Copilot', so an
+    # exact-string compare silently excluded every cloud PR. The filter must match
+    # any copilot-ish login case-insensitively.
+    assert "(?i)copilot" in content
 
 
 def test_playbook_present_and_links_helpers() -> None:

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -118,7 +118,22 @@ function Get-PrSignatureMap {
         # poll), so newly-opened cloud PRs join and merged ones drop on their own.
         if ($OnlyAuthors.Count -gt 0) {
             $login = if ($null -ne $p.author) { [string]$p.author.login } else { '' }
-            if ($OnlyAuthors -notcontains $login) { continue }
+            # The Copilot coding agent's author.login varies by API surface
+            # ('Copilot' from some endpoints, 'app/copilot-swe-agent' from
+            # `gh pr list --json author`, 'copilot-swe-agent', etc.). The sentinel
+            # 'Copilot' in the filter therefore matches ANY copilot-ish login
+            # case-insensitively; other entries (real usernames) match exactly.
+            # (Bug 2026-06-08: an exact 'Copilot' compare silently excluded every
+            # cloud PR, so -Mine only ever tracked my own PRs.)
+            $match = $false
+            foreach ($a in $OnlyAuthors) {
+                if ($a -eq 'Copilot') {
+                    if ($login -match '(?i)copilot') { $match = $true; break }
+                } elseif ($login -eq $a) {
+                    $match = $true; break
+                }
+            }
+            if (-not $match) { continue }
         }
         $wip = if ($p.title -match '\[WIP\]') { 'wip' } else { 'ready' }
         $draft = if ($p.isDraft) { 'draft' } else { 'open' }


### PR DESCRIPTION
﻿## Bug

`pr-watch.ps1 -Mine` matched the Copilot author by the literal string `Copilot`, but `gh pr list --json author` returns the bot's login as `app/copilot-swe-agent`. So -Mine silently excluded EVERY cloud PR and only ever tracked my own (Kixantrix) PRs — the watcher never woke on cloud work (e.g. #339/M3.3 merged untracked).

## Fix

The `Copilot` sentinel in the author filter now matches any copilot-ish login case-insensitively (`-match '(?i)copilot'`) — covers `Copilot`, `app/copilot-swe-agent`, `copilot-swe-agent`, `Copilot[bot]` — while real usernames still match exactly. Verified against all variants.

## Test

Regression assertion added to test_pr_loop_helpers.