### PR TITLE
docs(briefings): commit M3.3/M3.4/OPS.1 dispatch briefings

### DIFF
--- a/.specify/briefings/M3.3.md
+++ b/.specify/briefings/M3.3.md
@@ -1,0 +1,77 @@
+# M3.3: React Flow DAG canvas + auto-layout
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 3.
+
+> **Dependencies (both merged to `main`):** `external:M3.1` (`lib/plan-parser.ts`) and `external:M3.2` (`lib/status.ts`). Consume both **as-is**; do not edit them. No file overlap with any open PR.
+
+## Goal
+
+Add the **project detail route** that renders a project's plan as a **React Flow** DAG with **dagre auto-layout**. Custom stage nodes show the stage name + a status color (AC-005). Pan/zoom works; the canvas is interactive in **<1s for ≤200 nodes** (AC-003/004/005). This introduces the app's first **routing** (portfolio → project), which M2 deliberately deferred to here.
+
+## Consume these exact shapes (do not redefine)
+
+From [`lib/plan-parser.ts`](../../apps/kerrigan-dashboard/src/lib/plan-parser.ts):
+- `parsePlanMarkdown(markdown: string): PlanParseResult` → `{ nodes, edges, errors }` (always returned; `errors` may be non-empty).
+- `PlanStageNode { id; label; level: 2 | 3; parentId: string | null }`, `PlanStageEdge { from; to; kind: "parent" | "dependency" }`, `PlanStageGraph { nodes; edges }`.
+
+From [`lib/status.ts`](../../apps/kerrigan-dashboard/src/lib/status.ts):
+- `deriveStatuses(graph: PlanStageGraph, input: DeriveStatusesInput): Map<string, StageStatus>` — call this to get the per-stage status map for coloring.
+- `StageStatus` = `planned | dispatched | in-review | blocked | needs-attestation | needs-human-test | merged` (precedence documented in the module header).
+- `DeriveStatusesInput` = `{ prs, issues, blocks, reviewsByPr?, matcher? }` (the default `defaultStageMatcher` links a stage to PRs/issues/blocks whose title contains the stage id — reuse it).
+
+From [`lib/github.ts`](../../apps/kerrigan-dashboard/src/lib/github.ts) (offline-tolerant `GitHubResult<T>`) and [`lib/projects.ts`](../../apps/kerrigan-dashboard/src/lib/projects.ts) (`readProjects`, `Project`, `RepoRef`) — to source the status inputs, exactly as `lib/portfolio.ts` already does. Mirror portfolio's injectable pattern; do not re-fetch differently.
+
+## Design (pure layout core + thin React shell)
+
+1. **`lib/dag-layout.ts` (pure, new):** a function that takes a `PlanStageGraph` + the `Map<string, StageStatus>` and returns React Flow `nodes` + `edges` with **dagre-computed positions** (and a status field per node for coloring). No React imports — unit-testable without a DOM. This is where the ≤200-node performance budget is met (compute layout once, memoized).
+2. **`components/Dag/**` (new):** the React Flow canvas + a **custom stage node** component that renders the stage label and a status color. Pan/zoom via React Flow defaults. Respect the design tokens (see below). Keep the node component pure (props in, render out).
+3. **`routes/project/**` (new):** the project-detail route. Loads the project's `plan.md` text via an **injectable plan reader** (`(workingCopyPath) => Promise<string | null>`, default uses the Tauri fs API restricted to the M2.1 capability allowlist — read-only, scoped to declared `workingCopyPaths`; tests inject a fake), parses it with `parsePlanMarkdown`, sources PR/issue/block data via `github.ts` (offline-tolerant) + the blocks reader, derives statuses with `deriveStatuses`, and renders `Dag`. Degrade gracefully when the plan or GitHub is unavailable (empty/placeholder, no crash).
+4. **Routing:** introduce `react-router-dom`. `/` = the existing `PortfolioView`; `/project/:projectId` = this detail route. Wire each portfolio card to link to its project. **Tauri constraint:** the app is served from a static custom protocol, so use a router that works without server-side route handling (`HashRouter`, or a memory/data router) — do **not** assume `BrowserRouter` history works in the packaged shell. Keep `App.tsx`'s header chrome; swap the `<main>` body to the router outlet.
+
+## Status → color (design tokens only)
+
+Use the Tailwind tokens in [`tailwind.config.ts`](../../apps/kerrigan-dashboard/tailwind.config.ts) and the guidance in [`design-references.md`](../../specs/projects/kerrigan-dashboard/design-references.md). Suggested mapping (confirm against design-references):
+- `blocked` → red (true blocks only)
+- `needs-attestation` / `needs-human-test` → amber `accent` (needs-attention)
+- `in-review` / `dispatched` → `brand`
+- `merged` → green
+- `planned` → neutral
+Document the exact mapping in the node component.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/lib/dag-layout.ts` + `src/lib/dag-layout.test.ts` — new (pure layout + unit tests)
+- `apps/kerrigan-dashboard/src/components/Dag/**` — new (canvas + custom node)
+- `apps/kerrigan-dashboard/src/routes/project/**` — new (detail route + injectable plan reader)
+- `apps/kerrigan-dashboard/src/App.tsx` — introduce the router; keep header chrome
+- `apps/kerrigan-dashboard/src/routes/portfolio/PortfolioView.tsx` — make each card link to `/project/:projectId` (minimal change; do not restructure the view)
+- `apps/kerrigan-dashboard/package.json` — add `@xyflow/react` (React Flow v12), `@dagrejs/dagre` (+ `@types` if needed), `react-router-dom`. Nothing else.
+- `apps/kerrigan-dashboard/e2e/**` — new project-navigation spec + reference-plan fixtures
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/{plan-parser,status,github,projects,portfolio}.ts` (consume; never edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,acceptance-tests.md,architecture.md,design-references.md}`
+- The M1 pre-vis `specs/projects/kerrigan-dashboard/previs/index.html`
+- Everything else
+
+## What "done" looks like
+
+1. `pnpm -C apps/kerrigan-dashboard dev:web` renders `/` (portfolio); clicking a card navigates to `/project/:projectId`, which shows the plan as a React Flow DAG with dagre auto-layout, custom nodes labeled + status-colored, pan/zoom working.
+2. **Vitest unit tests** for `lib/dag-layout.ts`: graph → positioned nodes/edges (hierarchy + dependency edges represented; status field set; deterministic; handles empty graph and a ≤200-node graph within the perf budget — assert it returns in well under the interactivity target).
+3. **Playwright E2E** (web build via `vite preview`, fixture `projects.json` + intercepted GitHub): `portfolio-to-project` navigates portfolio → project and asserts the DAG renders the expected nodes; **visual-regression on three reference plans** (commit the reference plan fixtures + snapshots). An offline/no-plan case renders a placeholder, not a crash.
+4. Interactivity budget: with a ≤200-node reference plan, the canvas is interactive in <1s (assert in the layout unit test for compute, and a Playwright timing check for first interaction).
+5. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes. Smoke still passes.
+
+## Out of scope / plan adjustments (call out in the PR description)
+
+- **Plan editor pane** (Tiptap, click-node-to-scroll) — **M3.4** (this slice only renders the DAG).
+- **PR-flow particle overlay** — **M7** (it sits on top of this canvas later; keep the node/edge model clean so M7 can bind to it).
+- **`merged` status fidelity** is limited by `github.ts` having no merged-PR read path (same gap M2.4/M3.2 documented) — `deriveStatuses` colors what the available data proves; do **not** widen `github.ts` here.
+- Chat, inbox view, writes/dispatch — later milestones.
+
+## Notes
+
+- Keep `dag-layout.ts` pure and the node/edge model stable — **M7** (PR-flow overlay) and **M3.4** (editor sync) both bind to it.
+- React Flow v12 is `@xyflow/react` (not the legacy `react-flow-renderer`); use the current package. dagre via `@dagrejs/dagre`.
+- If a boundary is wrong (e.g. the Tauri static-serve constraint genuinely blocks the routing approach, or AC-003's perf target can't be met with dagre at 200 nodes), write `.specify/blocks/M3.3.yaml` with the reason + recommendation and stop — don't expand scope silently.

--- a/.specify/briefings/M3.4.md
+++ b/.specify/briefings/M3.4.md
@@ -1,0 +1,63 @@
+# M3.4: Plan editor pane (read-only Tiptap) + node-to-heading scroll
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 3.
+
+> **Dependency:** `external:M3.3` (DAG route) — merged to `main`. Build on the project route + `Dag` it added; consume them, extend minimally. No file overlap with the in-flight OPS.1/#343 (harness).
+
+## Goal
+
+Add a **read-only plan editor pane** to the project detail route: render the project's `plan.md` as formatted markdown via **Tiptap** (read-only), laid out beside the DAG. Selecting a node in the DAG scrolls the editor so the corresponding **stage heading** is visible (AC-008 prep for the M6 writable editor). Playwright asserts `heading.isVisibleInViewport()` within 250ms of a node click.
+
+## What already exists (consume / extend, don't rebuild)
+
+[`routes/project/ProjectView.tsx`](../../apps/kerrigan-dashboard/src/routes/project/ProjectView.tsx) (from M3.3):
+- Already reads the plan via an injectable `PlanReader = (workingCopyPath) => Promise<string | null>` (default Tauri fs; tests/E2E inject via the `__KERRIGAN_PLAN_FIXTURE__` window hook) and parses it with `parsePlanMarkdown`. **The raw plan markdown + the parsed `PlanStageGraph` are already in this component's state** — reuse them; do not re-read or re-parse.
+- Renders `<Dag graph={...} statuses={...} />`.
+
+[`components/Dag/Dag.tsx`](../../apps/kerrigan-dashboard/src/components/Dag/Dag.tsx): props `{ graph: PlanStageGraph; statuses }`. React Flow with `elementsSelectable`. **It does not yet surface node selection** — you'll add a small `onStageSelect?: (stageId: string) => void` prop wired to React Flow's `onNodeClick` (node id == `PlanStageNode.id`).
+
+[`lib/plan-parser.ts`](../../apps/kerrigan-dashboard/src/lib/plan-parser.ts): `PlanStageNode = { id; label; level: 2 | 3; parentId }`. **There are NO line numbers / offsets** on a stage node. So the editor maps a stage to its heading by **heading text (`stage.label`) + level**, not by line. Render headings so they're locatable (e.g. a stable `data-stage-id` / id attribute the editor can `scrollIntoView`).
+
+## Design
+
+- **`components/PlanEditor/**` (new):** a read-only Tiptap editor that renders the plan markdown. Parse markdown → Tiptap doc (use Tiptap's StarterKit + a markdown source; if a markdown extension is needed add one well-known dep). Each rendered heading carries a stable anchor derived from the stage id (mirror `plan-parser`'s slug derivation so ids line up — or expose a shared slug helper). Expose a `scrollToStage(stageId)` (imperative via ref, or a `selectedStageId` prop that triggers a `scrollIntoView` effect).
+- **`ProjectView.tsx` (extend):** add `selectedStageId` state; lay out a **left PlanEditor pane + right DAG** (per [`design-references.md`](../../specs/projects/kerrigan-dashboard/design-references.md)); pass `onStageSelect={setSelectedStageId}` to `Dag` and `selectedStageId` to `PlanEditor`. Degrade gracefully when the plan is missing/unparseable (the route already tracks `missingPlan`/`parseErrors` — show the existing placeholder, no crash).
+- **`Dag.tsx` (minimal):** add the optional `onStageSelect` prop + `onNodeClick`. Keep it backward-compatible (prop optional).
+
+## Hard constraints
+
+- **Read-only** this slice — no editing/writes (that's M6). No git/PR side effects.
+- Consume M3.3/M3.1 as-is; the only edits outside `components/PlanEditor/**` are the **small additive** `selectedStageId` wiring in `ProjectView.tsx` and the `onStageSelect` prop in `Dag.tsx`. Don't restructure the DAG or the route's data flow.
+- Strict TS, design tokens only (see `tailwind.config.ts` + `design-references.md`). No `any`.
+- Keep the plan markdown the single source — the editor renders what `ProjectView` already loaded; don't re-fetch.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/components/PlanEditor/**` — new (Tiptap read-only editor + heading anchors + scroll)
+- `apps/kerrigan-dashboard/src/routes/project/ProjectView.tsx` — add the pane + `selectedStageId` wiring (additive)
+- `apps/kerrigan-dashboard/src/components/Dag/Dag.tsx` — add optional `onStageSelect` prop (additive)
+- `apps/kerrigan-dashboard/package.json` — add Tiptap (`@tiptap/react`, `@tiptap/starter-kit`, + a markdown bridge if needed)
+- `apps/kerrigan-dashboard/e2e/**` — extend the project spec with the node-click→scroll assertion
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/{plan-parser,status,dag-layout}.ts`, `components/Dag/StageNode.tsx`
+- `specs/projects/kerrigan-dashboard/{spec.md,acceptance-tests.md,design-references.md}`
+- Everything else
+
+## What "done" looks like
+
+1. The project route shows the plan as formatted read-only markdown beside the DAG.
+2. Clicking a DAG node scrolls the editor so that stage's heading is in view. **Playwright** asserts the heading `isVisibleInViewport()` within 250ms of the click (extend the existing `e2e/project.spec.ts`).
+3. **Vitest component test** for `PlanEditor` (renders markdown; `scrollToStage`/`selectedStageId` brings the right heading into view with a mocked scroll).
+4. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` passes. Smoke still passes.
+
+## Out of scope
+
+- Writable editing / markdown round-trip / branch-per-edit — **M6**.
+- PR-flow particle overlay — **M7**.
+
+## Notes
+
+- Heading↔stage id alignment is the crux: reuse `plan-parser`'s slug logic (extract a shared helper if cleaner) so DAG node ids and editor heading anchors match exactly.
+- If matching a stage to its heading genuinely can't be done reliably without line numbers from the parser, write `.specify/blocks/M3.4.yaml` recommending a parser change (add `lineStart` to `PlanStageNode`) rather than hacking around it.

--- a/.specify/briefings/OPS.1.md
+++ b/.specify/briefings/OPS.1.md
@@ -1,0 +1,95 @@
+# OPS.1: Option C migration — merge queue via a single ruleset (checks + merge_queue)
+
+Harness task. Makes the merge queue actually enable-able so the human can "flip the switch" with one gated `-Apply` later.
+
+> **Dependency:** PR #340 (declarative repo-protection tooling) must be **merged to `main`** before starting — this task extends the files it introduces. Build on top of them; do not recreate them.
+
+## Background (what we learned the hard way)
+
+`tools/configure-repo-protection.ps1` currently sets required checks via **classic branch protection** and then tries to add a **separate** `merge_queue` ruleset. GitHub rejects that with an opaque `422 "Invalid rule 'merge_queue': "` — the merge queue conflicts with required checks living in classic protection. Confirmed during the 2026-06-08 live attempt:
+
+- The repo is public (plan is not the blocker).
+- `merge_method` must be **UPPERCASE** (`SQUASH`/`MERGE`/`REBASE`); a squash-only repo must use `SQUASH` (default `MERGE` is rejected with "Not allowed for this repository").
+- The **full** `parameters` object is required — a partial one fails the schema with "data matches no possible input".
+- Even with schema-valid params, a *separate* merge_queue ruleset fails while classic protection still owns the required checks.
+
+The fix: express the **required status checks rule AND the merge_queue rule in ONE ruleset**, and stop using classic protection for required checks.
+
+## Goal
+
+Rework the apply tool (and config/validator/tests/docs) so that applying the
+Kerrigan shape creates a **single repository ruleset** for `main` containing:
+1. a `required_status_checks` rule listing the required check contexts, and
+2. a `merge_queue` rule (uppercase `merge_method`, full parameters),
+
+and **removes the now-duplicated required-status-checks from classic branch
+protection** (so they don't conflict). Keep `strict` handling consistent (with a
+queue, strict-up-to-date is not needed). Everything stays **dry-run by default**;
+the live `-Apply` against shared infra is **human-run only** — the cloud agent
+must NOT attempt to mutate this repo's protection.
+
+## Scope / design
+
+- **`tools/configure-repo-protection.ps1`:**
+  - Build one ruleset (name e.g. `Kerrigan main protection`) whose `rules` array
+    includes both `{ type: "required_status_checks", parameters: { required_status_checks: [ { context }... ], strict_required_status_checks_policy: <bool> } }` and `{ type: "merge_queue", parameters: {...} }`. Confirm the exact `required_status_checks` rule parameter shape against the GitHub rulesets schema.
+  - Idempotent create-or-update by ruleset name (GET /rulesets → PUT or POST).
+  - On `-Apply`, also PATCH classic `required_status_checks` to **clear** the
+    contexts (so the ruleset is the single source of gating) — gated, reversible,
+    and clearly logged.
+  - Keep the existing `Protect PRs` ruleset (thread resolution + Copilot review +
+    squash) untouched, OR fold its rules in — pick one and document it. Simplest:
+    leave `Protect PRs` as-is and add the new checks+queue ruleset.
+  - Preserve dry-run-default + `-Apply` gating. Payloads written ASCII/no-BOM
+    (the utf8-BOM bug was already fixed in #340 — keep it).
+- **`.github/repo-protection.json` + `preset/kerrigan/repo-protection.json`:**
+  add whatever fields the ruleset approach needs (e.g. `protection_mode: "ruleset"`),
+  keeping back-compat / sensible defaults. Don't break the existing schema the
+  validator reads.
+- **`tools/validators/check_merge_queue.py`:** the "every required check runs on
+  `merge_group`" invariant still applies — keep it correct for the ruleset-sourced
+  required checks (it reads `required_checks` from the config, so likely no change,
+  but verify).
+- **Tests:** unit-test the **payload builder** (one ruleset with both rules;
+  uppercase `SQUASH`; full merge_queue params; required_status_checks rule shape;
+  the classic-protection-clear step is planned). Assert dry-run prints both
+  payloads and that nothing mutates without `-Apply`. Mirror the existing
+  `tests/test_configure_repo_protection.py` style (static + dry-run; the live
+  apply is not exercised in CI).
+- **`playbooks/repo-protection.md`:** update the "Known limitation" section into
+  the resolved approach (single ruleset), and the order-of-operations.
+
+## Hard constraints
+
+- **Do NOT run `-Apply` against any live repository.** Build + unit-test the
+  payload construction and dry-run output only. The human runs the gated apply.
+- **No secrets, no token handling.** The tool shells to `gh` which handles auth.
+- Strict TS/PS hygiene; keep the tool PowerShell 5.1-compatible (this repo's shell).
+- Stay within the Touch set below; if the ruleset schema genuinely needs a
+  different shape than described, write `.specify/blocks/OPS.1.yaml` with the
+  finding + recommendation and stop.
+
+## Files in scope (Touch)
+
+- `tools/configure-repo-protection.ps1`
+- `.github/repo-protection.json`, `preset/kerrigan/repo-protection.json`
+- `tools/validators/check_merge_queue.py` (only if needed)
+- `tests/test_configure_repo_protection.py` (+ `tests/test_check_merge_queue.py` if the validator changes)
+- `playbooks/repo-protection.md`
+
+## What "done" looks like
+
+1. `configure-repo-protection.ps1` dry-run prints a plan that creates a **single
+   ruleset** with both `required_status_checks` and `merge_queue` rules (uppercase
+   `SQUASH`, full params), plus the planned classic-protection clear.
+2. Tests cover the payload builder + dry-run-default + apply-gating; `pnpm`/python
+   test + lint clean; `kerrigan check` passes (the merge-queue validator still green).
+3. Playbook updated; the "flip the switch" step is a single human-run
+   `configure-repo-protection.ps1 -Repo <r> -Apply`.
+4. The PR explicitly notes that **no live protection was changed** by this PR.
+
+## Notes
+
+- This unblocks the human flipping `kerrigan` to a real merge queue, and makes the
+  same shape reproducible across satellites.
+- Reference the live-attempt learnings above so you don't repeat the 422 loop.


### PR DESCRIPTION
Commits the three dispatch briefings that rode as untracked while their issues were dispatched (#339 M3.3, #344/#345 M3.4, #341/#343 OPS.1). Traceability docs only - matches the pattern of the earlier committed briefings. No code.