### PR TITLE
docs(briefings): M4.2/M6.1/M7.1 dispatch briefings

### DIFF
--- a/.specify/briefings/M4.2.md
+++ b/.specify/briefings/M4.2.md
@@ -1,0 +1,66 @@
+# M4.2: ACP event renderers + chat pane UI
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 4.
+
+> **Dependency:** `external:M4.1` (`lib/acp-client.ts`) — merged. Consume it as-is. Fully isolated to `components/Chat/**` — no overlap with the parallel M6.1/M7.1.
+
+## Goal
+
+Build the right-pane **chat UI** that renders the ACP event stream from `lib/acp-client.ts` as distinct React components, with an input affordance (submit + cancel) and error surfaces for offline / missing-CLI. Implements the vanilla portion of **AC-010**.
+
+## Consume this exact shape (do not redefine)
+
+From [`lib/acp-client.ts`](../../apps/kerrigan-dashboard/src/lib/acp-client.ts):
+- `AcpEvent` discriminated union — render one component per `type`:
+  - `{ type: "message_chunk"; text }` — streaming assistant text (append/coalesce chunks)
+  - `{ type: "tool_call"; name; input }`
+  - `{ type: "tool_result"; name; output }`
+  - `{ type: "thought"; text }`
+  - `{ type: "turn_end"; reason? }` — terminal marker for a turn
+  - `{ type: "error"; error: AcpClientError }`
+- `AcpClient` = `{ sendUserTurn(text): AsyncIterable<AcpEvent>; dispose(): Promise<void> }`.
+- `createAcpClient(...)` / `createDefaultAcpSpawn()` build the real client; **inject** an `AcpClient` into the chat component so tests drive a fake (do not spawn a real subprocess in tests).
+- Error types: `AcpClientError` (`.code`), `CopilotCliNotFoundError`, etc. — surface their messages as actionable error UI.
+
+## Design
+
+- **`components/Chat/**` (new):** a chat pane that takes an injected `AcpClient` (prop/context, default = the real one). On submit, call `sendUserTurn(text)` and consume the `AsyncIterable<AcpEvent>`, appending rendered events to a transcript. A `switch` over `AcpEvent.type` maps to per-variant components (exhaustive — no `default: any`).
+- **Input affordance:** text input + submit; a **cancel** control that stops the in-flight turn (dispose/abort the current iterator). Disable submit while a turn streams.
+- **Error surface:** offline / `CopilotCliNotFoundError` / CLI-too-old render a clear, actionable banner (consume the typed error messages), not a crash.
+- Pure rendering — the transport lives in `acp-client.ts`; the chat component only consumes the event stream.
+
+## Hard constraints
+
+- Consume `acp-client.ts` as-is; do not edit it. No subprocess spawning in component code paths under test (inject a fake `AcpClient`).
+- Strict TS, no `any`; the event `switch` must be exhaustive over the union.
+- Design tokens only (`tailwind.config.ts` + [`design-references.md`](../../specs/projects/kerrigan-dashboard/design-references.md)); restrained styling, no emoji.
+- **Do not touch `ProjectView.tsx` / `App.tsx` routing** in this slice (mounting the chat pane into the app layout can be a tiny follow-up; keep this PR isolated to `components/Chat/**` + its tests). If a mount point is needed for the E2E, use a thin local harness/story, not the shared route.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/components/Chat/**` — new (pane + per-event renderers + input)
+- `apps/kerrigan-dashboard/src/components/Chat/*.test.tsx` — Vitest component tests
+- `apps/kerrigan-dashboard/e2e/**` — a chat smoke spec against a stub `AcpClient`
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/acp-client.ts` (consume; never edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,acceptance-tests.md,design-references.md}`
+
+## What "done" looks like
+
+1. The chat pane renders each `AcpEvent` variant as its own component; streaming `message_chunk`s coalesce into a growing assistant message.
+2. Input submits a turn; cancel stops an in-flight turn; submit disabled while streaming.
+3. Offline / missing-CLI render the actionable error banner (no crash).
+4. **Vitest** component tests for each event type + the error path (fake `AcpClient`). **Playwright** smoke opens chat and exchanges one message against a stub backend.
+5. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` + smoke pass.
+
+## Out of scope
+
+- The MCP server + `kerrigan.dispatch` and sidecar wiring — **M5**.
+- Mounting the pane into the project route layout / chat-driven actions — later (keep isolated).
+
+## Notes
+
+- The `AcpEvent` union is your contract — exhaustive `switch`, no fallthrough-any.
+- If a needed event field isn't on the union, write `.specify/blocks/M4.2.yaml` recommending an `acp-client.ts` change rather than casting.

--- a/.specify/briefings/M6.1.md
+++ b/.specify/briefings/M6.1.md
@@ -1,0 +1,58 @@
+# M6.1: Tiptap writable + markdown round-trip
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 6.
+
+> **Dependency:** `external:M3.4` (`components/PlanEditor`) — merged. Extend it. Isolated to `components/PlanEditor/**` — no overlap with parallel M4.2/M7.1.
+
+## Goal
+
+Make the read-only PlanEditor **writable** with a **markdown round-trip**: edits serialize back to markdown that is **byte-equivalent for unchanged regions**, Ctrl-S + blur both save, and undo/redo work. Implements the editing core of **AC-008** (the git round-trip / branch-per-edit is **M6.2**, out of scope here).
+
+## What already exists (extend, don't rebuild)
+
+[`components/PlanEditor/PlanEditor.tsx`](../../apps/kerrigan-dashboard/src/components/PlanEditor/PlanEditor.tsx) (from M3.4):
+- Props `{ markdown: string; selectedStageId: string | null }`.
+- Tiptap (`@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/extension-heading`) with **`editable: false`**; markdown → HTML via `markdown-it` (`renderPlanMarkdown`); a custom `AnchoredHeading` adds `id` / `data-stage-id` for the node-scroll feature.
+- Renders content via `editor.commands.setContent(...)`.
+
+## Design
+
+- **Make it editable:** add an `editable` mode (prop, default keep read-only so existing read-only usage is unchanged) and an `onSave(markdown: string)` callback. When editable, `editor.editable = true`.
+- **Markdown round-trip (the crux):** serialize the Tiptap document **back to markdown**. `markdown-it` is markdown→HTML only — you need the reverse. Use a well-known Tiptap markdown bridge (e.g. `tiptap-markdown`) or a custom ProseMirror→markdown serializer. **Byte-equivalence for unchanged regions** is the hard requirement: prefer an approach that preserves original source for untouched blocks (e.g. keep the source markdown + only re-serialize changed nodes, or use a serializer whose output matches the input formatting). Validate with a property test over a corpus of sample plans (round-trip an unedited doc → identical bytes).
+- **Save triggers:** Ctrl-S (and Cmd-S) and editor blur both call `onSave(currentMarkdown)`. Undo/redo via StarterKit history (ensure enabled).
+- **Preserve the M3.4 behaviors:** the `selectedStageId` scroll-to-heading and the `AnchoredHeading` anchors must still work in editable mode.
+
+## Hard constraints
+
+- **Stay within `components/PlanEditor/**`.** Do **not** edit `ProjectView.tsx` (the route can adopt the editable mode + wire `onSave` in a tiny follow-up; keeping this PR isolated avoids colliding with the parallel M7.1). Expose the new `editable`/`onSave` API; don't wire it into the shared route here.
+- **No git / PR side effects** — `onSave` just hands back the markdown string. Branch-per-edit + draft PR is **M6.2**.
+- Strict TS, no `any`. Design tokens only.
+- Round-trip must be **lossless for unchanged regions** — this is the acceptance bar; don't ship a serializer that reflows/normalizes untouched markdown.
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/components/PlanEditor/**` — editable mode + markdown serialization + save triggers + tests
+- `apps/kerrigan-dashboard/package.json` — add a Tiptap markdown serializer dep if needed (e.g. `tiptap-markdown`)
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/plan-parser.ts` (heading/slug alignment), `routes/project/ProjectView.tsx` (see how PlanEditor is used — do not edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,acceptance-tests.md,design-references.md}`
+
+## What "done" looks like
+
+1. PlanEditor supports an editable mode; typing edits the doc; undo/redo work.
+2. Ctrl-S / Cmd-S and blur both fire `onSave(markdown)`.
+3. **Vitest property test**: round-tripping an unedited corpus of sample plans returns **byte-identical** markdown; an edit to one block changes only that block's serialization.
+4. The M3.4 `selectedStageId` scroll + heading anchors still work in editable mode (component test).
+5. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` + smoke pass.
+
+## Out of scope
+
+- Branch-per-edit-session + draft PR — **M6.2**.
+- Conflict detection / offline edit queue — **M6.3**.
+- Wiring editable mode into the project route — later (keep isolated).
+
+## Notes
+
+- If byte-equivalent round-trip is genuinely unachievable with available serializers (markdown normalization unavoidable), write `.specify/blocks/M6.1.yaml` with the finding + options (e.g. source-preserving diff approach) rather than shipping a lossy round-trip.

--- a/.specify/briefings/M7.1.md
+++ b/.specify/briefings/M7.1.md
@@ -1,0 +1,62 @@
+# M7.1: Canvas particle system overlay
+
+Single-dispatch task from [`specs/projects/kerrigan-dashboard/tasks.md`](../../specs/projects/kerrigan-dashboard/tasks.md) Milestone 7.
+
+> **Dependency:** `external:M3.3` (DAG) — merged. This slice is the **self-contained overlay engine** only; binding it to real PR states + mounting on the live DAG is **M7.2**. Isolated to `components/PrFlowOverlay/**` — no overlap with parallel M4.2/M6.1, and it deliberately does **not** edit `ProjectView`/`Dag` yet.
+
+## Goal
+
+Build the **PR-flow particle overlay** — the spec's single **show-stopper** (AC-020). A lightweight canvas overlay that emits particles from a source point to a target point: open PRs stream a faint particle (work in motion), merged PRs absorb into the target. 60fps with ≤20 simultaneous particles; respects `prefers-reduced-motion` (renders static markers instead). Implements **AC-006/AC-007/AC-020** at the engine level (the lifecycle binding to PR data is M7.2).
+
+## Spec / design (consume)
+
+From [`spec.md`](../../specs/projects/kerrigan-dashboard/spec.md) § Show-stopper + AC-006/007/020 and [`design-references.md`](../../specs/projects/kerrigan-dashboard/design-references.md) "Show-stopper detail":
+- A particle trail flows from a PR source point into a plan-stage target node on the DAG canvas; **open** PRs = faint streaming particle; **merged** = clean absorption + the node pulses green.
+- **Motion budget:** calm, ≤2s per flow, "not a sparkle storm"; restrained, mechanical easing. Exactly **one** show-stopper — don't add competing flourishes.
+- Reference feel: "Apple Maps route being calculated — particles tracing an arc."
+- The M1 pre-vis chose a variant — match it (`specs/projects/kerrigan-dashboard/previs/index.html`).
+
+## Design (self-contained engine)
+
+- **`components/PrFlowOverlay/**` (new):** a `<canvas>` overlay component that sits above a container (absolute-positioned, `pointer-events: none`, transparent). It exposes an imperative/declarative API to drive particle flows independent of the DAG, e.g.:
+  - a `flows` prop or a ref API: `emit({ id, from: {x,y}, to: {x,y}, state: "streaming" | "absorbing" })`.
+  - `state: "streaming"` → continuous faint particles along the arc; `"absorbing"` → a one-shot absorb + a target pulse signal (expose an `onAbsorbed(id)` or a pulse callback the DAG node can react to in M7.2).
+- **Performance:** a single `requestAnimationFrame` loop, one canvas, object-pooled particles; hold **60fps with ≤20 simultaneous particles**. No per-particle React state.
+- **`prefers-reduced-motion`:** when set, render **static markers** (e.g. a small dot/line at source→target) instead of animation — no rAF churn.
+- **Self-contained:** the component takes source/target points in its own coordinate space; it does **not** read the DAG, PR data, or `ProjectView`. M7.2 will compute node screen-positions and feed them in + bind to PR lifecycle. Provide a small **demo/story harness** (local, not wired into the route) to drive the overlay for tests/visual-diff.
+
+## Hard constraints
+
+- **Do not edit `ProjectView.tsx` / `Dag.tsx`** — keep this PR entirely within `components/PrFlowOverlay/**` (+ its tests + a local demo harness). The mount-on-DAG + PR-state binding is M7.2; isolating this slice keeps it conflict-free with M6.1.
+- **One show-stopper (AC-020):** this is *the* animation — keep it restrained; no extra sparkle.
+- 60fps / ≤20 particles is the perf bar; `prefers-reduced-motion` must fully bypass the animation loop.
+- Strict TS, no `any`. Design tokens for colors (green pulse = the `merged` status color; streaming = a faint `brand`/neutral particle).
+
+## Files in scope (Touch)
+
+- `apps/kerrigan-dashboard/src/components/PrFlowOverlay/**` — new (canvas overlay engine + API + local demo harness)
+- `apps/kerrigan-dashboard/src/components/PrFlowOverlay/*.test.ts(x)` — perf + behavior tests
+- `apps/kerrigan-dashboard/e2e/**` — a visual-diff spec driving the demo harness
+
+## Read-only
+
+- `apps/kerrigan-dashboard/src/lib/dag-layout.ts`, `components/Dag/**` (understand the node model M7.2 will bind to — do not edit)
+- `specs/projects/kerrigan-dashboard/{spec.md,design-references.md,previs/index.html}`
+
+## What "done" looks like
+
+1. `PrFlowOverlay` renders a transparent canvas; driving it with a streaming flow shows faint particles tracing an arc source→target; an absorbing flow does a clean absorb + emits a pulse signal.
+2. **Vitest performance harness:** frame timing under load stays at ~60fps with 20 simultaneous particles (assert frame budget); object pooling verified (no unbounded allocation).
+3. `prefers-reduced-motion` renders static markers and does **not** start the rAF loop (test the media-query branch).
+4. **Playwright visual diff** against the M1 pre-vis chosen variant, driving the demo harness.
+5. `pnpm -C apps/kerrigan-dashboard test` + `lint` + `tsc --noEmit` clean. `kerrigan check` + smoke pass.
+
+## Out of scope
+
+- Binding particles to real PR open/merge lifecycle + mounting on the live DAG with node screen-coords — **M7.2**.
+- Node green-pulse rendering inside `StageNode` — M7.2 wires the pulse signal; this slice just emits it.
+
+## Notes
+
+- Keep the API clean and coordinate-space-agnostic so M7.2 can feed DAG node screen positions without reworking the engine.
+- If 60fps with 20 particles genuinely can't be met with canvas 2D (e.g. needs WebGL), write `.specify/blocks/M7.1.yaml` with the measurement + recommendation rather than shipping a janky overlay.


### PR DESCRIPTION
Briefings for the M4/M6/M7 fan-out wave (#347 M4.2 chat, #349 M6.1 writable editor, #351 M7.1 PR-flow overlay). Docs only.