### PR TITLE
fix(pr-watch): suppress non-actionable head-only wakes during draft+wip

### DIFF
--- a/tests/test_pr_loop_helpers.py
+++ b/tests/test_pr_loop_helpers.py
@@ -107,6 +107,18 @@ def test_pr_watch_mine_mode_derives_author_set() -> None:
     assert "(?i)copilot" in content
 
 
+def test_pr_watch_suppresses_wip_head_noise() -> None:
+    # A head-only change while a PR is still draft+wip is the cloud agent
+    # iterating mid-build (many commits/min) — non-actionable. The delta must
+    # suppress it (still firing on wip->ready, merge, and review changes).
+    content = _read("tools/pr-watch.ps1")
+    assert "$onlyHeadChanged" in content
+    assert "$stillDraftWip" in content
+    # The signature fields it compares (state/draft/wip/reviewDecision unchanged,
+    # head changed) and the draft+wip guard.
+    assert "'draft'" in content and "'wip'" in content
+
+
 def test_playbook_present_and_links_helpers() -> None:
     playbook = REPO_ROOT / "playbooks" / "cloud-agent-pr-loop.md"
     assert playbook.exists()

--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -191,6 +191,21 @@ function Get-SignatureDelta {
             $changes += "PR #${num}: NEW open PR ($($Current[$num]))"
         }
         elseif ($Baseline[$num] -ne $Current[$num]) {
+            # Signature = state|draft|wip|headRefOid|reviewDecision.
+            # A head-only change while the PR is still draft+wip is the cloud
+            # agent iterating mid-build - NOT actionable (we act on the [WIP]->
+            # ready flip, a merge/close, or a review). Suppress it so active WIP
+            # development does not spam non-actionable wakes. Any change to
+            # state/draft/wip/reviewDecision still fires. (2026-06-08.)
+            $oldParts = $Baseline[$num] -split '\|'
+            $newParts = $Current[$num] -split '\|'
+            $onlyHeadChanged = ($oldParts[0] -eq $newParts[0]) -and `
+                ($oldParts[1] -eq $newParts[1]) -and `
+                ($oldParts[2] -eq $newParts[2]) -and `
+                ($oldParts[4] -eq $newParts[4]) -and `
+                ($oldParts[3] -ne $newParts[3])
+            $stillDraftWip = ($newParts[1] -eq 'draft') -and ($newParts[2] -eq 'wip')
+            if ($onlyHeadChanged -and $stillDraftWip) { continue }
             $changes += "PR #${num}: changed`n    was: $($Baseline[$num])`n    now: $($Current[$num])"
         }
     }


### PR DESCRIPTION
During active cloud development a PR gets many commits/min; each head change fired the watcher even though the PR is still [WIP] (non-actionable). The delta now suppresses a head-only change when the PR is still draft+wip, while still firing on wip->ready, merge/close, and review-decision changes. Verified across all cases; regression test added.