### PR TITLE
docs(dashboard): add deferred M9 cross-project integrated chat milestone

### DIFF
--- a/specs/projects/kerrigan-dashboard/plan.md
+++ b/specs/projects/kerrigan-dashboard/plan.md
@@ -163,6 +163,21 @@ The Tauri app lives under `apps/` so it can coexist with future apps without ren
 
 **Exit criteria**: conductor processes ≥10 inbox items in ≤2 minutes during walkthrough.
 
+### M9 — Cross-project integrated chat (deferred to v2)
+
+**Goal**: Add a workspace-level chat surface that can operate across multiple projects without forcing a single-project context first.
+
+**Deliverables**:
+- Global chat route (or drawer) reachable from portfolio/inbox views.
+- Context selector allowing `all projects` or explicit project scopes.
+- Session model for chat threads with scope metadata (`global` vs project-bound).
+- Tool-call refresh fan-out: tool results invalidate only affected projects/panes.
+- Prompt templates for multi-project intents (triage, dispatch, status synthesis).
+
+**Acceptance**: v2 AC amendment required (new ACs for multi-project chat scope, thread persistence, and context safety).
+
+**Exit criteria**: conductor can ask one global question (for example, "what needs intervention across all projects?") and receive a scoped, actionable response with links back to affected projects.
+
 ## Cross-cutting concerns
 
 ### Testing strategy
@@ -206,6 +221,7 @@ The Tauri app lives under `apps/` so it can coexist with future apps without ren
 - M5 depends on M4. M6 depends on M3.
 - M7 depends on M3. Can run in parallel with M5/M6 in a later wave.
 - M8 depends on M5 (uses MCP tools internally).
+- M9 depends on M4 + M8 and is intentionally deferred to v2.
 
 Approximate wave structure (`.specify/waves.yaml` generated during `/kerrigan.dispatch`):
 
@@ -215,6 +231,7 @@ wave-2: M2 (Tauri skeleton + portfolio)
 wave-3: M3 (DAG) + M4 (chat)            # parallel
 wave-4: M5 (MCP) + M6 (plan editor)     # parallel
 wave-5: M7 (show-stopper) + M8 (inbox)  # parallel
+wave-6: M9 (cross-project chat, v2)     # deferred
 ```
 
 ## Tasks

--- a/specs/projects/kerrigan-dashboard/tasks.md
+++ b/specs/projects/kerrigan-dashboard/tasks.md
@@ -11,6 +11,7 @@ Wave structure (from [`plan.md`](./plan.md#sequencing-notes)):
 - **wave-3**: M3 + M4 tasks parallel.
 - **wave-4**: M5 + M6 tasks parallel.
 - **wave-5**: M7 + M8 tasks parallel.
+- **wave-6**: M9 deferred (cross-project integrated chat).
 
 Within a milestone, tasks are sequenced by their declared dependencies. The conductor regenerates `.specify/waves.yaml` before each dispatch via `kerrigan-conflict-predictor`.
 
@@ -244,6 +245,20 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
     - external:M5.2
   - Touch: `apps/kerrigan-dashboard/src/components/CaptureTriage/**`
   - Tests: Playwright E2E captures → triage → draft PR via `plan-update`
+
+---
+
+## Milestone 9: Cross-project integrated chat (wave-6, deferred to v2)
+
+- [ ] Task M9.1: Workspace-level chat surface + scoped context model
+  - Done when: a global chat entrypoint is available from portfolio/inbox; user can scope chat to `all projects` or selected project subset; chat sessions persist with scope metadata; tool-result refreshes fan out only to affected projects; at least one E2E flow validates cross-project query → actionable result links
+  - Links: plan.md M9 (deferred); spec.md Goal and scenarios
+  - Dependencies:
+    - external:M4.2
+    - external:M8.2
+    - external:M5.4
+  - Touch: `apps/kerrigan-dashboard/src/routes/**`, `apps/kerrigan-dashboard/src/components/Chat/**`, `apps/kerrigan-dashboard/src/lib/**`
+  - Tests: Vitest unit for scope selection/session model + Playwright E2E for cross-project chat workflow
 
 ---
 


### PR DESCRIPTION
Adds explicit deferred-v2 planning artifacts for cross-project integrated chat so the expected feature is tracked in both plan and tasks.

Changes:
- plan.md: add M9 milestone (deferred to v2), dependencies, wave-6 note
- tasks.md: add M9.1 task with done-when and test coverage expectations

Tracking issue: #377