### PR TITLE
tools: add sync-main.ps1 + dashboard-dev.ps1 helper scripts

### DIFF
--- a/tools/dashboard-dev.ps1
+++ b/tools/dashboard-dev.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+  Launch the kerrigan-dashboard dev server, robustly, on Windows.
+
+.DESCRIPTION
+  Wraps the launch dance the conductor repeated ~6 times during the dashboard
+  session:
+    - free port 1420 if a stale Vite/Tauri process is holding it (the recurring
+      "Port 1420 is already in use" failure),
+    - refresh PATH from User+Machine so a freshly-installed global `pnpm` resolves,
+    - launch either the full native Tauri app (default) or the web-only Vite server
+      (-Web), the latter being the browser harness used for Playwright iteration.
+
+  With -Live, writes apps/kerrigan-dashboard/.env.local with a GitHub token from
+  `gh auth token` so the *web* build (no Tauri) can hit live GitHub via the
+  dev-auth path (VITE_GH_TOKEN). The token is never echoed. .env.local is gitignored.
+
+  Run this ASYNC (run_in_terminal mode=async) since the dev server is long-running.
+
+.PARAMETER Web
+  Run the web-only Vite server (pnpm dev:web) instead of the native Tauri app.
+  Use this for browser-based Playwright iteration.
+
+.PARAMETER Live
+  Write apps/kerrigan-dashboard/.env.local with VITE_GH_TOKEN from `gh auth token`
+  so the web build can load live GitHub data. Implies the dev-auth browser path.
+  Dev-only; never use the token in a production build.
+
+.PARAMETER Port
+  Dev server port to free before launch. Defaults to 1420.
+
+.EXAMPLE
+  .\tools\dashboard-dev.ps1
+  Launch the native Tauri dev app.
+
+.EXAMPLE
+  .\tools\dashboard-dev.ps1 -Web -Live
+  Launch the web-only server with live GitHub data for browser/Playwright iteration.
+#>
+[CmdletBinding()]
+param(
+  [switch]$Web,
+  [switch]$Live,
+  [int]$Port = 1420
+)
+
+$ErrorActionPreference = 'Continue'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$appDir = Join-Path $repoRoot 'apps/kerrigan-dashboard'
+
+# 1. Free the dev port if held by a stale process.
+$listener = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($listener) {
+  Stop-Process -Id $listener.OwningProcess -Force -ErrorAction SilentlyContinue
+  Write-Host "[OK] Freed port $Port (pid $($listener.OwningProcess))" -ForegroundColor Green
+}
+else {
+  Write-Host "[OK] Port $Port is free" -ForegroundColor Green
+}
+
+# 2. Optionally write the dev-auth token for the web/browser live path.
+if ($Live) {
+  $token = (& gh auth token 2>$null)
+  if ([string]::IsNullOrWhiteSpace($token)) {
+    Write-Host "[WARN] 'gh auth token' returned nothing; is gh authenticated? Skipping .env.local." -ForegroundColor Yellow
+  }
+  else {
+    $envPath = Join-Path $appDir '.env.local'
+    # Write UTF-8 no-BOM, no trailing newline; never echo the token.
+    [System.IO.File]::WriteAllText($envPath, "VITE_GH_TOKEN=$token", (New-Object System.Text.UTF8Encoding($false)))
+    Write-Host "[OK] Wrote dev token to apps/kerrigan-dashboard/.env.local (gitignored, not echoed)" -ForegroundColor Green
+  }
+}
+
+# 3. Refresh PATH so a freshly-installed global pnpm resolves.
+$env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'User') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+
+# 4. Launch.
+$script = if ($Web) { 'dev:web' } else { 'tauri dev' }
+Write-Host "Launching kerrigan-dashboard ($script)$(if($Live){' [live data]'})..." -ForegroundColor Cyan
+if ($Web) {
+  & pnpm --filter kerrigan-dashboard dev:web
+}
+else {
+  & pnpm --filter kerrigan-dashboard tauri dev
+}

--- a/tools/sync-main.ps1
+++ b/tools/sync-main.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+  Fast-forward the local checkout to origin/<branch> (default: main), robustly.
+
+.DESCRIPTION
+  Wraps the `git fetch` + `git merge --ff-only` dance that the conductor ran by
+  hand 10+ times during the dashboard session. Centralizes two recurring papercuts:
+    - git writes progress to stderr, which PowerShell surfaces as a NativeCommandError
+      and aborts chained `;` commands. We funnel stderr to the host explicitly.
+    - `git pull --ff-only` can fail with "Cannot fast-forward to multiple branches"
+      when refspecs are ambiguous; an explicit fetch + ff-merge avoids it.
+
+  Prints the short HEAD before/after and the list of changed files, and leaves any
+  local uncommitted changes untouched (it refuses to merge if the tree is dirty in a
+  way that would block a fast-forward).
+
+.PARAMETER Branch
+  The branch to sync to. Defaults to 'main'.
+
+.PARAMETER Remote
+  The remote to fetch from. Defaults to 'origin'.
+
+.EXAMPLE
+  .\tools\sync-main.ps1
+  Fetches origin and fast-forwards local main.
+
+.EXAMPLE
+  .\tools\sync-main.ps1 -Branch develop
+#>
+[CmdletBinding()]
+param(
+  [string]$Branch = 'main',
+  [string]$Remote = 'origin'
+)
+
+$ErrorActionPreference = 'Continue'
+
+function Invoke-Git {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GitArgs)
+  # Run git and surface stderr as normal text so a progress line doesn't abort the script.
+  & git @GitArgs 2>&1 | ForEach-Object { Write-Host $_ }
+  return $LASTEXITCODE
+}
+
+$before = (& git rev-parse --short HEAD 2>$null)
+Write-Host "Current HEAD: $before" -ForegroundColor Cyan
+
+Write-Host "Fetching $Remote ..." -ForegroundColor Cyan
+$code = Invoke-Git fetch $Remote
+if ($code -ne 0) {
+  Write-Host "[FAIL] git fetch $Remote exited $code" -ForegroundColor Red
+  exit $code
+}
+
+Write-Host "Fast-forwarding to $Remote/$Branch ..." -ForegroundColor Cyan
+$code = Invoke-Git merge --ff-only "$Remote/$Branch"
+if ($code -ne 0) {
+  Write-Host "[FAIL] Could not fast-forward to $Remote/$Branch (diverged or dirty tree?). Resolve manually." -ForegroundColor Red
+  exit $code
+}
+
+$after = (& git rev-parse --short HEAD 2>$null)
+if ($before -eq $after) {
+  Write-Host "[OK] Already up to date at $after" -ForegroundColor Green
+}
+else {
+  Write-Host "[OK] $before -> $after" -ForegroundColor Green
+  Write-Host "Changed files:" -ForegroundColor Cyan
+  & git --no-pager diff --name-only "$before..$after" 2>&1 | ForEach-Object { Write-Host "  $_" }
+}
+
+# Surface any leftover working-tree changes so the conductor notices stray files.
+$dirty = (& git status --porcelain 2>$null)
+if ($dirty) {
+  Write-Host "Working tree (uncommitted / untracked):" -ForegroundColor Yellow
+  $dirty | ForEach-Object { Write-Host "  $_" -ForegroundColor Yellow }
+}


### PR DESCRIPTION
## Summary

Adds two small PowerShell helpers that wrap command sequences I hand-rolled many times this session (and which kept tripping PowerShell's "native stderr = error" quirk):

- `tools/sync-main.ps1` — checkout main + `git fetch` + `git merge --ff-only origin/main`, swallowing the benign `From <remote>` stderr, printing the new HEAD and any untracked files. Replaces the fragile `git pull --ff-only 2>&1 | Out-Host` chain that aborted mid-command on stderr.
- `tools/dashboard-dev.ps1` — frees port 1420, refreshes PATH from User+Machine, and launches the dashboard. `-Web` runs the browser harness (`dev:web` only, ensuring `.env.local` has a `VITE_GH_TOKEN` for live data); default runs the native Tauri app. Replaces the repeated `Stop-Process on 1420; $env:Path = ...; pnpm --filter kerrigan-dashboard ...` incantation.

## Why

Per the script-first convention: any multi-step terminal flow repeated across sessions should be a named tool (consistent, auto-approvable, no stderr footguns). These two were the most-repeated uncovered flows this session.

## Test plan

- `tools/sync-main.ps1` run locally: fast-forwards cleanly, reports HEAD + untracked, exit 0.
- `tools/dashboard-dev.ps1 -Web` / native: frees the port and launches.
- No behavior change to existing tools.
