### PR TITLE
plan(dashboard): add M10 ongoing maintenance & enhancements milestone

### DIFF
--- a/specs/projects/kerrigan-dashboard/plan.md
+++ b/specs/projects/kerrigan-dashboard/plan.md
@@ -178,6 +178,22 @@ The Tauri app lives under `apps/` so it can coexist with future apps without ren
 
 **Exit criteria**: conductor can ask one global question (for example, "what needs intervention across all projects?") and receive a scoped, actionable response with links back to affected projects.
 
+### M10 — Maintenance & enhancements (ongoing)
+
+**Goal**: A living milestone for post-M8 maintenance and dogfood-driven enhancements. Unlike M1–M8 (discrete, sequential), **M10 is open-ended** — new tasks are appended as work is identified (bugs caught while dogfooding, UX refinements, runtime/harness fixes the dashboard surfaces about itself).
+
+**Convention**: dispatch every M10 task as an `M10.x:`-prefixed issue so it links to this stage. That makes the dashboard show its **own** in-flight status (`dispatched` / `in-review` / `merged`) — exercising, on itself, the exact pipeline used to track other projects.
+
+**Deliverables (representative; this list extends over time)**:
+- Status accuracy: merged-status data source, milestone↔work auto-linkage, matcher precision.
+- Project detail: per-stage PR details panel, sub-milestone grouping, DAG left-to-right spine, legend.
+- Runtime: Tauri fs + `gh auth` wiring, offline-reason surfacing, dev-browser harness.
+- Cockpit: MCP sidecar, chat-pane mount.
+
+**Acceptance**: each `M10.x` task ships with its own tests + green CI. No single exit criterion.
+
+**Exit criteria**: none — M10 stays open for the life of the project; it is the maintenance lane.
+
 ## Cross-cutting concerns
 
 ### Testing strategy
@@ -222,6 +238,7 @@ The Tauri app lives under `apps/` so it can coexist with future apps without ren
 - M7 depends on M3. Can run in parallel with M5/M6 in a later wave.
 - M8 depends on M5 (uses MCP tools internally).
 - M9 depends on M4 + M8 and is intentionally deferred to v2.
+- M10 is the ongoing maintenance lane — no dependency, never "done"; tasks are appended as work is identified.
 
 Approximate wave structure (`.specify/waves.yaml` generated during `/kerrigan.dispatch`):
 
@@ -232,6 +249,7 @@ wave-3: M3 (DAG) + M4 (chat)            # parallel
 wave-4: M5 (MCP) + M6 (plan editor)     # parallel
 wave-5: M7 (show-stopper) + M8 (inbox)  # parallel
 wave-6: M9 (cross-project chat, v2)     # deferred
+ongoing: M10 (maintenance & enhancements)  # living lane, appended over time
 ```
 
 ## Tasks

--- a/specs/projects/kerrigan-dashboard/tasks.md
+++ b/specs/projects/kerrigan-dashboard/tasks.md
@@ -262,6 +262,32 @@ Within a milestone, tasks are sequenced by their declared dependencies. The cond
 
 ---
 
+## Milestone 10: Maintenance & enhancements (ongoing)
+
+> **Living milestone.** Append `M10.x` tasks as work is identified. Dispatch each as an `M10.x:`-prefixed issue so it links to the M10 stage and exercises the dashboard's own in-flight status. Unlike M1–M9, this milestone never closes.
+
+**Completed (dogfood-driven, this lane):**
+- Status accuracy: merged-status data source (#385), milestone↔work auto-linkage via closing-PR traversal (#387), matcher precision title+branch (#394).
+- Project detail: per-stage PR details panel (#390), sub-milestone grouping (#396), DAG left-to-right spine (#400), legend (#392).
+- Runtime: Tauri fs + `withGlobalTauri` (#372), `gh auth token` shell-out (#380/#389), offline-reason + dev-browser auth (#383).
+- Cockpit foundation: MCP sidecar lib (#401).
+
+**Open:**
+
+- [ ] Task M10.1: Scope sub-milestone grouping to the current stage's milestone (no foreign `Mx.y` groups)
+  - Done when: a stage panel shows only its own milestone's sub-groups; foreign sub-ids are not surfaced; unit + Playwright cover it
+  - Links: plan.md M10
+  - Touch: `apps/kerrigan-dashboard/src/components/StageDetailPanel/groupStageItems.ts`
+  - Tracked as: #403
+
+- [ ] Task M10.2: Mount chat pane + wire MCP sidecar into ProjectView (cockpit)
+  - Done when: project view shows a chat pane backed by `copilot --acp` with the Kerrigan MCP tools; tool results refresh affected panes; missing-CLI error surfaced
+  - Links: plan.md M10; M4.x + M5.x
+  - Touch: `apps/kerrigan-dashboard/src/routes/project/ProjectView.tsx`, `apps/kerrigan-dashboard/src/components/Chat/**`
+  - Tracked as: #404
+
+---
+
 ## Notes for the conductor
 
 - Re-run `kerrigan-conflict-predictor` before each wave dispatch; the `Touch` field above is authoritative for overlap detection.


### PR DESCRIPTION
## Summary

Adds an **M10 "Maintenance & enhancements (ongoing)"** milestone to the kerrigan-dashboard plan + tasks. Per conductor direction, the plan is a living document that extends as work is identified.

## Why
- The dashboard's plan was M1–M9; all post-M8 dogfood-driven work (status accuracy, PR panel, sub-milestones, DAG-LR, legend, runtime/auth fixes, MCP sidecar, chat cockpit) had no home in the plan, so the dashboard tracking *itself* could only ever show **merged** stages.
- M10 is an open-ended maintenance lane. Convention: dispatch each task as an `M10.x:`-prefixed issue so it links to the M10 stage — which makes the dashboard surface its **own** `dispatched`/`in-review`/`merged` status, exercising the same pipeline used to track other projects (the in-flight states that were previously unvalidated).

## Changes
- `plan.md`: new `### M10 — Maintenance & enhancements (ongoing)` section + sequencing/wave notes.
- `tasks.md`: new `## Milestone 10` section listing completed dogfood work (with PR refs) and the open `M10.1` (grouping-scope, #403) / `M10.2` (chat cockpit, #404) tasks.

## Test plan
- `check_artifacts` (CI): additive markdown only; no file/section removed; spec.md/architecture.md unchanged.
