### PR TITLE
Fix Windows 'pick an app' dialog from Claude Code hooks

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -80,12 +80,12 @@ Hooks are wired in `.claude/settings.local.json`:
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [{ "type": "command", "command": ".claude/hooks/pre-tool-use.sh" }]
+        "hooks": [{ "type": "command", "command": "bash .claude/hooks/pre-tool-use.sh" }]
       }
     ],
     "Stop": [
       {
-        "hooks": [{ "type": "command", "command": ".claude/hooks/stop-verify.sh" }]
+        "hooks": [{ "type": "command", "command": "bash .claude/hooks/stop-verify.sh" }]
       }
     ]
   }
@@ -110,9 +110,24 @@ Or rely on the Git attribute — the scripts are committed with execute bits set
 
 ---
 
+## Cross-platform invocation (Windows)
+
+Hook `command` strings **must** be prefixed with `bash` (e.g.
+`bash .claude/hooks/pre-tool-use.sh`), not a bare `.sh` path.
+
+On Windows a bare `.sh` path is handed to the shell, which has no file
+association for `.sh` and pops the **"How do you want to open this file? /
+Pick an app"** dialog. Because `PreToolUse` fires before every Bash tool call,
+those dialogs pile up. Prefixing with `bash` routes the script through Git Bash
+(shipped with Git for Windows), so it runs instead of prompting. The scripts
+still self-degrade to no-ops outside Claude Code via their environment-variable
+checks.
+
+---
+
 ## Out of scope
 
-- Windows-specific hooks (PowerShell equivalents are not provided; hooks are
-  skipped on Windows because `CLAUDE_TOOL_NAME` / `CLAUDE_SESSION_ID` are not
-  set in that context).
+- Windows-specific hook logic (PowerShell equivalents are not provided; the
+  Bash scripts run under Git Bash and are no-ops when `CLAUDE_TOOL_NAME` /
+  `CLAUDE_SESSION_ID` are not set).
 - Modifying Claude Code itself.

--- a/.claude/hooks/stop-verify.sh
+++ b/.claude/hooks/stop-verify.sh
@@ -12,7 +12,7 @@
 #
 # Usage (configured via .claude/settings.local.json):
 #   { "hooks": { "Stop": [{ "hooks": [{ "type": "command",
-#     "command": ".claude/hooks/stop-verify.sh" }] }] } }
+#     "command": "bash .claude/hooks/stop-verify.sh" }] }] } }
 
 set -euo pipefail
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/pre-tool-use.sh"
+            "command": "bash .claude/hooks/pre-tool-use.sh"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/stop-verify.sh"
+            "command": "bash .claude/hooks/stop-verify.sh"
           }
         ]
       }


### PR DESCRIPTION
## Problem

On Windows, the Claude Code hooks in `.claude/settings.local.json` were wired with a bare `.sh` path:

```json
"command": ".claude/hooks/pre-tool-use.sh"
```

Windows hands that straight to the shell. `.sh` has no file association, so it pops the **"How do you want to open this file? / Pick an app"** dialog. Because the `PreToolUse` hook fires before *every* Bash tool call (and `Stop` at session end), the dialogs pile up. The script's own "skip on Windows" env-var guard never runs — Windows can't even launch the file to reach it.

## Fix

Invoke the scripts through `bash` so Git Bash (shipped with Git for Windows) runs them:

```json
"command": "bash .claude/hooks/pre-tool-use.sh"
```

Cross-platform (works on macOS/Linux too); the scripts stay no-ops outside Claude Code via their env checks. Also updates `.claude/hooks/README.md` config examples + the now-inaccurate Windows note, and the usage comment in `stop-verify.sh`.

The same fix was applied across the other affected repos: pushed directly to `sunday-league`, and opened as PRs for `your-voice` (#5) and `vhs-video-stack` (#196).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>