### PR TITLE
fix(hooks): make Claude PreToolUse guard work under Copilot CLI on Windows

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -79,13 +79,13 @@ Hooks are wired in `.claude/settings.local.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
-        "hooks": [{ "type": "command", "command": ".claude/hooks/pre-tool-use.sh" }]
+        "matcher": "Bash|bash|shell|powershell",
+        "hooks": [{ "type": "command", "command": ".claude/hooks/pre-tool-use.sh", "powershell": "...inline guard..." }]
       }
     ],
     "Stop": [
       {
-        "hooks": [{ "type": "command", "command": ".claude/hooks/stop-verify.sh" }]
+        "hooks": [{ "type": "command", "command": ".claude/hooks/stop-verify.sh", "powershell": "exit 0" }]
       }
     ]
   }
@@ -95,6 +95,44 @@ Hooks are wired in `.claude/settings.local.json`:
 `settings.local.json` is a **repo-level** settings file loaded by Claude Code
 when it opens this repository. It complements (and does not replace) any
 personal `~/.claude/settings.json`.
+
+---
+
+## Cross-tool note: GitHub Copilot CLI reads these hooks too
+
+GitHub Copilot CLI also loads `.claude/settings.json` / `.claude/settings.local.json`
+from the repository as one of its hook sources, and merges them with its own
+(`.github/hooks/*.json`, user-level hooks, etc.). All sources fire; any one of
+them can deny a tool call. That has two consequences on Windows:
+
+1. **`command` is copied to both shells.** Copilot's command-hook schema has
+   `bash`, `powershell`, and a cross-platform `command` fallback. An entry with
+   only `command: "bash …"` is used verbatim on Windows, where `bash` is usually
+   not on `PATH`.
+2. **`preToolUse` is fail-closed.** A hook that crashes (including
+   "command not found") *denies* the tool call. So a missing `bash` turns the
+   guard into a blanket deny of every shell command, reported as
+   `Denied by preToolUse hook from "repo settings" (hook errored)`.
+
+Both entries therefore carry an explicit `powershell` field, which takes
+precedence over `command` on Windows:
+
+- `PreToolUse` — an inline PowerShell twin of the destructive-pattern guard. It
+  reads the payload from stdin, emits a `permissionDecision: deny` object when a
+  destructive pattern matches, and always exits `0` (so it can never fail-closed
+  by accident). It is written inline rather than as a `.ps1` file so it does not
+  depend on `PATH`, the hook's working directory, or PowerShell execution policy.
+  The deny JSON is built with `ConvertTo-Json` instead of a quoted literal,
+  because quotes are stripped when the command is passed through `-Command`.
+- `Stop` — `exit 0`. The verify chain stays Claude-Code-only on purpose: Copilot
+  maps `Stop` to `agentStop`, which fires after **every turn**, not once per
+  session, so running `kerrigan check` there would be wrong (and slow).
+
+The `matcher` is `Bash|bash|shell|powershell` so it matches both Claude's `Bash`
+tool name and the runtime shell tool names Copilot surfaces.
+
+Keep `command` pointing at the bash scripts — that is what Claude Code uses, and
+what Copilot uses on Unix.
 
 ---
 
@@ -112,7 +150,8 @@ Or rely on the Git attribute — the scripts are committed with execute bits set
 
 ## Out of scope
 
-- Windows-specific hooks (PowerShell equivalents are not provided; hooks are
-  skipped on Windows because `CLAUDE_TOOL_NAME` / `CLAUDE_SESSION_ID` are not
-  set in that context).
+- Windows-specific hook *scripts* (no `.ps1` twins of `pre-tool-use.sh` /
+  `stop-verify.sh`). Claude Code on Windows runs the bash scripts through Git
+  Bash; Copilot CLI on Windows uses the inline `powershell` commands described
+  above.
 - Modifying Claude Code itself.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,11 +2,12 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|bash|shell|powershell",
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/pre-tool-use.sh"
+            "command": ".claude/hooks/pre-tool-use.sh",
+            "powershell": "$in=''; try { $in=[Console]::In.ReadToEnd() } catch { }; if ($in -match 'rm\\s+-(rf|fr)\\s+(/(?![A-Za-z0-9_])|~|\\$HOME)|mkfs\\.|dd\\s[^|]*of=/dev/[sh]d') { Write-Output (@{ permissionDecision = 'deny'; permissionDecisionReason = 'pre-tool-use: destructive command pattern blocked' } | ConvertTo-Json -Compress) }; exit 0"
           }
         ]
       }
@@ -16,7 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/stop-verify.sh"
+            "command": ".claude/hooks/stop-verify.sh",
+            "powershell": "exit 0"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Every shell tool call in a **GitHub Copilot CLI** session on Windows is rejected with:

```
Denied by preToolUse hook from "repo settings" (hook errored)
```

A guard meant to block `rm -rf /` becomes a blanket deny of all shell access.

## Root cause

Three things combine:

1. Copilot CLI loads `.claude/settings.json` / `.claude/settings.local.json` from the repo as one of its hook sources (documented cross-tool compatibility). All hook sources are merged, and any one of them can deny.
2. Copilot's command-hook schema has `bash`, `powershell`, and a cross-platform `command` fallback. Our entries only set `command`, which Copilot copies into **both** shells — so on Windows it runs the bash script line through PowerShell, where it errors (`bash` isn't on `PATH`, and a bare `.sh` path isn't executable).
3. `preToolUse` command hooks are **fail-closed**: a crash — including "command not found" — denies the tool call.

The Claude-format matcher `Bash` also maps to the `powershell` runtime tool, so it matched every shell call.

## Fix

Add an explicit `powershell` field to each hook entry (it takes precedence over `command` on Windows):

- **`PreToolUse`** — an inline PowerShell twin of the destructive-pattern guard. Reads the payload from stdin, emits a `permissionDecision: deny` object when a destructive pattern matches, and **always exits 0** so it can never fail-closed by accident. Written inline rather than as a `.ps1` so it doesn't depend on `PATH`, the hook's working directory, or PowerShell execution policy. The deny JSON is built with `ConvertTo-Json` rather than a quoted literal, because quotes get stripped when a command string is passed through `-Command`.
- **`Stop`** — `exit 0`. The verify chain stays Claude-Code-only on purpose: Copilot maps `Stop` to `agentStop`, which fires after **every turn**, not once per session, so running `kerrigan check` there would be both wrong and slow.
- **`matcher`** — broadened to `Bash|bash|shell|powershell` to cover Claude's tool name and the runtime shell tool names Copilot surfaces.

`command` is unchanged, so **Claude Code behaviour is unchanged**. `.claude/hooks/README.md` documents the cross-tool behaviour and the reasoning.

## Verification

Hook command exercised directly with real payloads:

| Command in payload | Expected | Result |
|---|---|---|
| `git status`, `pnpm test`, `npm run build` | allow | ✅ |
| `rm -rf /tmp/scratch` | allow — not over-blocking | ✅ |
| `rm -rf /` | deny | ✅ |
| `rm -rf / --no-preserve-root` | deny | ✅ |
| `rm -rf ~` | deny | ✅ |
| `mkfs.ext4 /dev/sda1` | deny | ✅ |
| `dd if=/dev/zero of=/dev/sda` | deny | ✅ |

9/9 cases pass, all exiting 0.

The identical fix was verified **end-to-end in a live Copilot session** in [`Kixantrix/your-voice#10`](https://github.com/Kixantrix/your-voice/pull/10): benign commands ran, a destructive-pattern command was denied with the guard's own reason text, and instrumenting the hook confirmed Copilot executed the PowerShell branch (`bash` was never invoked).
